### PR TITLE
V4 plugin and pvaDriver updates

### DIFF
--- a/ADApp/Db/pvaDriver.template
+++ b/ADApp/Db/pvaDriver.template
@@ -21,3 +21,20 @@ record(ai, "$(P)$(R)OverrunCounter_RBV")
     field(SCAN, "I/O Intr")
 }
 
+record(waveform, "$(P)$(R)PvName")
+{
+    field(DTYP, "asynOctetRead")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PV_NAME")
+    field(FTVL, "CHAR")
+    field(NELM, "256")
+    field(SCAN, "I/O Intr")
+}
+
+record(bi, "$(P)$(R)PvConnection")
+{
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PV_CONNECTION")
+    field(SCAN, "I/O Intr")
+    field(ONAM, "up")
+    field(ZNAM, "down")
+}

--- a/ADApp/commonLibraryMakefile
+++ b/ADApp/commonLibraryMakefile
@@ -16,11 +16,6 @@ ifeq ($(EPICS_V4_PLUGIN),YES)
   LIB_LIBS              += nt
   LIB_LIBS              += pvAccess
   LIB_LIBS              += ntndArrayConverter
-
-  pvData_DIR             = $(EV4_BASE)/pvDataCPP/lib/$(EPICS_HOST_ARCH)/
-  pvDatabase_DIR         = $(EV4_BASE)/pvDatabaseCPP/lib/$(EPICS_HOST_ARCH)/
-  nt_DIR                 = $(EV4_BASE)/normativeTypesCPP/lib/$(EPICS_HOST_ARCH)/
-  pvAccess_DIR           = $(EV4_BASE)/pvAccessCPP/lib/$(EPICS_HOST_ARCH)/
 endif
 
 # The following libraries are only needed for GraphicsMagick

--- a/ADApp/ntndArrayConverterSrc/Makefile
+++ b/ADApp/ntndArrayConverterSrc/Makefile
@@ -7,8 +7,6 @@ include $(TOP)/configure/CONFIG
 LIBRARY_IOC += ntndArrayConverter
 INC += ntndArrayConverter.h
 LIB_SRCS += ntndArrayConverter.cpp
-USR_INCLUDES += -I$(EV4_BASE)/pvDataCPP/include
-USR_INCLUDES += -I$(EV4_BASE)/normativeTypesCPP/include
 
 #=============================
 

--- a/ADApp/ntndArrayConverterSrc/ntndArrayConverter.cpp
+++ b/ADApp/ntndArrayConverterSrc/ntndArrayConverter.cpp
@@ -326,7 +326,7 @@ void NTNDArrayConverter::toStringAttribute (NDArray *dest, PVStructurePtr src)
 
 void NTNDArrayConverter::toAttributes (NDArray *dest)
 {
-    typedef typename PVStructureArray::const_svector::const_iterator VecIt;
+    typedef PVStructureArray::const_svector::const_iterator VecIt;
 
     PVStructureArray::const_svector srcVec(m_array->getAttribute()->view());
 

--- a/ADApp/op/edl/autoconvert/ADCollect.edl
+++ b/ADApp/op/edl/autoconvert/ADCollect.edl
@@ -24,6 +24,21 @@ gridSize 5
 endScreenProperties
 
 
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 0
+y 0
+w 350
+h 405
+lineColor index 14
+fillColor index 14
+lineWidth 0
+endObjectProperties
+
 # (Group)
 object activeGroupClass
 beginObjectProperties
@@ -644,21 +659,6 @@ endGroup
 
 endObjectProperties
 
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 0
-y 0
-w 350
-h 405
-lineColor index 14
-fillColor index 14
-lineWidth 0
-endObjectProperties
 
 # (Group)
 object activeGroupClass

--- a/ADApp/op/edl/autoconvert/ADDriverFile.edl
+++ b/ADApp/op/edl/autoconvert/ADDriverFile.edl
@@ -218,7 +218,7 @@ icon
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDFile.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDFile.edl
 }
 menuLabel {
   0 

--- a/ADApp/op/edl/autoconvert/ADPlugins.edl
+++ b/ADApp/op/edl/autoconvert/ADPlugins.edl
@@ -183,13 +183,13 @@ icon
 numPvs 14
 numDsps 7
 displayFileName {
-  0 adl/NDFileNetCDF.edl
-  1 adl/NDFileTIFF.edl
-  2 adl/NDFileJPEG.edl
-  3 adl/NDFileNexus.edl
-  4 adl/NDFileMagick.edl
-  5 adl/NDFileHDF5.edl
-  6 adl/NDFileNull.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDFileNetCDF.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDFileTIFF.edl
+  2 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDFileJPEG.edl
+  3 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDFileNexus.edl
+  4 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDFileMagick.edl
+  5 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDFileHDF5.edl
+  6 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDFileNull.edl
 }
 menuLabel {
   0 netCDF file #1
@@ -230,12 +230,12 @@ icon
 numPvs 12
 numDsps 6
 displayFileName {
-  0 adl/NDStats.edl
-  1 adl/NDStats.edl
-  2 adl/NDStats.edl
-  3 adl/NDStats.edl
-  4 adl/NDStats.edl
-  5 adl/NDStats5.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStats.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStats.edl
+  2 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStats.edl
+  3 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStats.edl
+  4 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStats.edl
+  5 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStats5.edl
 }
 menuLabel {
   0 Statistics #1
@@ -274,11 +274,11 @@ icon
 numPvs 10
 numDsps 5
 displayFileName {
-  0 adl/NDROI.edl
-  1 adl/NDROI.edl
-  2 adl/NDROI.edl
-  3 adl/NDROI.edl
-  4 adl/NDROI4.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDROI.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDROI.edl
+  2 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDROI.edl
+  3 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDROI.edl
+  4 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDROI4.edl
 }
 menuLabel {
   0 ROI #1
@@ -315,16 +315,16 @@ icon
 numPvs 24
 numDsps 12
 displayFileName {
-  0 adl/NDStdArrays.edl
-  1 adl/NDProcess.edl
-  2 adl/NDTransform.edl
-  3 adl/NDColorConvert.edl
-  4 adl/NDColorConvert.edl
-  5 adl/NDOverlay.edl
-  6 adl/NDOverlay8.edl
-  7 adl/NDCircularBuff.edl
-  8 adl/NDROIStat.edl
-  9 adl/NDPluginAttribute.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStdArrays.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDProcess.edl
+  2 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTransform.edl
+  3 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDColorConvert.edl
+  4 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDColorConvert.edl
+  5 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlay.edl
+  6 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlay8.edl
+  7 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDCircularBuff.edl
+  8 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDROIStat.edl
+  9 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDPluginAttribute.edl
   10 scan_more.adl
   11 yySseq.adl
 }
@@ -377,7 +377,7 @@ buttonLabel "All"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/commonPlugins.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/commonPlugins.edl
 }
 menuLabel {
   0 Common plugins

--- a/ADApp/op/edl/autoconvert/ADShutter.edl
+++ b/ADApp/op/edl/autoconvert/ADShutter.edl
@@ -400,7 +400,7 @@ icon
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/ADEpicsShutter.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADEpicsShutter.edl
 }
 menuLabel {
   0 EPICS shutter setup

--- a/ADApp/op/edl/autoconvert/ADTop.edl
+++ b/ADApp/op/edl/autoconvert/ADTop.edl
@@ -460,7 +460,7 @@ icon
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 adsc.adl
 }
 menuLabel {
@@ -492,9 +492,9 @@ icon
 numPvs 10
 numDsps 5
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 Andor.adl
-  2 adl/ADBase.edl
+  2 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   3 Andor3.adl
   4 Shamrock.adl
 }
@@ -533,8 +533,8 @@ icon
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/ADBase.edl
-  1 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
 }
 menuLabel {
   0 aravisGigE #1 general
@@ -578,10 +578,10 @@ icon
 numPvs 8
 numDsps 4
 displayFileName {
-  0 adl/ADBase.edl
-  1 adl/simDetector.edl
-  2 adl/ADBase.edl
-  3 adl/simDetector.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/simDetector.edl
+  2 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
+  3 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/simDetector.edl
 }
 menuLabel {
   0 Simulator #1 General
@@ -616,9 +616,9 @@ icon
 numPvs 8
 numDsps 4
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 prosilica.adl
-  2 adl/ADBase.edl
+  2 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   3 prosilica.adl
 }
 menuLabel {
@@ -654,7 +654,7 @@ icon
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 pilatusDetector.adl
 }
 menuLabel {
@@ -686,7 +686,7 @@ icon
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 marCCD.adl
 }
 menuLabel {
@@ -718,7 +718,7 @@ icon
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 Roper.adl
 }
 menuLabel {
@@ -750,7 +750,7 @@ icon
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 firewire.adl
 }
 menuLabel {
@@ -782,7 +782,7 @@ icon
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 mar345.adl
 }
 menuLabel {
@@ -814,7 +814,7 @@ icon
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 PerkinElmer.adl
 }
 menuLabel {
@@ -846,7 +846,7 @@ icon
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 pvCam.adl
 }
 menuLabel {
@@ -878,7 +878,7 @@ icon
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 URLDriver.adl
 }
 menuLabel {
@@ -910,7 +910,7 @@ icon
 numPvs 6
 numDsps 3
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 LightField.adl
   2 LightField.adl
 }
@@ -945,7 +945,7 @@ icon
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 pixirad.adl
 }
 menuLabel {
@@ -977,7 +977,7 @@ icon
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 pointGrey.adl
 }
 menuLabel {
@@ -1009,7 +1009,7 @@ icon
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 PSL.adl
 }
 menuLabel {
@@ -1059,7 +1059,7 @@ icon
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 BIS.adl
 }
 menuLabel {
@@ -1096,7 +1096,7 @@ icon
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
   1 Dexela.adl
 }
 menuLabel {

--- a/ADApp/op/edl/autoconvert/NDOverlay.edl
+++ b/ADApp/op/edl/autoconvert/NDOverlay.edl
@@ -224,14 +224,14 @@ buttonLabel "Individual Overlays"
 numPvs 16
 numDsps 8
 displayFileName {
-  0 adl/NDOverlayN.edl
-  1 adl/NDOverlayN.edl
-  2 adl/NDOverlayN.edl
-  3 adl/NDOverlayN.edl
-  4 adl/NDOverlayN.edl
-  5 adl/NDOverlayN.edl
-  6 adl/NDOverlayN.edl
-  7 adl/NDOverlayN.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlayN.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlayN.edl
+  2 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlayN.edl
+  3 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlayN.edl
+  4 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlayN.edl
+  5 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlayN.edl
+  6 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlayN.edl
+  7 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlayN.edl
 }
 menuLabel {
   0 Overlay 1
@@ -275,8 +275,8 @@ buttonLabel "Combined Overlays"
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/NDOverlay8.edl
-  1 adl/NDOverlay8.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlay8.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlay8.edl
 }
 menuLabel {
   0 Overlays 1-8

--- a/ADApp/op/edl/autoconvert/NDOverlay8.edl
+++ b/ADApp/op/edl/autoconvert/NDOverlay8.edl
@@ -5298,7 +5298,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDOverlayN.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlayN.edl
 }
 menuLabel {
   0 Full Overlay
@@ -5406,7 +5406,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDOverlayN.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlayN.edl
 }
 menuLabel {
   0 Full Overlay
@@ -5514,7 +5514,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDOverlayN.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlayN.edl
 }
 menuLabel {
   0 Full Overlay
@@ -5622,7 +5622,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDOverlayN.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlayN.edl
 }
 menuLabel {
   0 Full Overlay
@@ -5730,7 +5730,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDOverlayN.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlayN.edl
 }
 menuLabel {
   0 Full Overlay
@@ -5838,7 +5838,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDOverlayN.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlayN.edl
 }
 menuLabel {
   0 Full Overlay
@@ -5946,7 +5946,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDOverlayN.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlayN.edl
 }
 menuLabel {
   0 Full Overlay
@@ -6054,7 +6054,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDOverlayN.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlayN.edl
 }
 menuLabel {
   0 Full Overlay

--- a/ADApp/op/edl/autoconvert/NDPluginBase.edl
+++ b/ADApp/op/edl/autoconvert/NDPluginBase.edl
@@ -24,6 +24,21 @@ gridSize 5
 endScreenProperties
 
 
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 0
+y 0
+w 380
+h 530
+lineColor index 14
+fillColor index 14
+lineWidth 0
+endObjectProperties
+
 # (Text Control)
 object activeXTextDspClass
 beginObjectProperties
@@ -1081,21 +1096,6 @@ endGroup
 
 endObjectProperties
 
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 0
-y 0
-w 380
-h 530
-lineColor index 14
-fillColor index 14
-lineWidth 0
-endObjectProperties
 
 # (Group)
 object activeGroupClass

--- a/ADApp/op/edl/autoconvert/NDROI4.edl
+++ b/ADApp/op/edl/autoconvert/NDROI4.edl
@@ -2763,7 +2763,7 @@ icon
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDROI.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDROI.edl
 }
 menuLabel {
   0 ROI #4 full
@@ -2832,7 +2832,7 @@ icon
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDROI.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDROI.edl
 }
 menuLabel {
   0 ROI #3 full
@@ -2901,7 +2901,7 @@ icon
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDROI.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDROI.edl
 }
 menuLabel {
   0 ROI #2 full
@@ -2970,7 +2970,7 @@ icon
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDROI.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDROI.edl
 }
 menuLabel {
   0 ROI #1 full

--- a/ADApp/op/edl/autoconvert/NDStats.edl
+++ b/ADApp/op/edl/autoconvert/NDStats.edl
@@ -2562,7 +2562,7 @@ icon
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDPlot.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDPlot.edl
 }
 menuLabel {
   0 netCDF file #1
@@ -2757,14 +2757,14 @@ icon
 numPvs 16
 numDsps 8
 displayFileName {
-  0 adl/NDPlot.edl
-  1 adl/NDPlot.edl
-  2 adl/NDPlot.edl
-  3 adl/NDPlot.edl
-  4 adl/NDPlot.edl
-  5 adl/NDPlot.edl
-  6 adl/NDPlot.edl
-  7 adl/NDPlot.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDPlot.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDPlot.edl
+  2 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDPlot.edl
+  3 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDPlot.edl
+  4 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDPlot.edl
+  5 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDPlot.edl
+  6 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDPlot.edl
+  7 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDPlot.edl
 }
 menuLabel {
   0 Average X
@@ -3096,12 +3096,12 @@ icon
 numPvs 12
 numDsps 6
 displayFileName {
-  0 adl/NDTimeSeries.edl
-  1 adl/NDTimeSeries.edl
-  2 adl/NDTimeSeries.edl
-  3 adl/NDTimeSeries.edl
-  4 adl/NDTimeSeries.edl
-  5 adl/NDTimeSeriesAll.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  2 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  3 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  4 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  5 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeriesAll.edl
 }
 menuLabel {
   0 Centroid X
@@ -3199,17 +3199,17 @@ icon
 numPvs 22
 numDsps 11
 displayFileName {
-  0 adl/NDTimeSeries.edl
-  1 adl/NDTimeSeries.edl
-  2 adl/NDTimeSeries.edl
-  3 adl/NDTimeSeries.edl
-  4 adl/NDTimeSeries.edl
-  5 adl/NDTimeSeries.edl
-  6 adl/NDTimeSeries.edl
-  7 adl/NDTimeSeries.edl
-  8 adl/NDTimeSeries.edl
-  9 adl/NDTimeSeries.edl
-  10 adl/NDTimeSeriesAll.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  2 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  3 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  4 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  5 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  6 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  7 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  8 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  9 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  10 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeriesAll.edl
 }
 menuLabel {
   0 Total

--- a/ADApp/op/edl/autoconvert/NDStats5.edl
+++ b/ADApp/op/edl/autoconvert/NDStats5.edl
@@ -2788,10 +2788,10 @@ icon
 numPvs 8
 numDsps 4
 displayFileName {
-  0 adl/NDStats.edl
-  1 adl/NDTimeSeries.edl
-  2 adl/NDTimeSeries.edl
-  3 adl/NDTimeSeriesAll.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStats.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  2 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  3 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeriesAll.edl
 }
 menuLabel {
   0 Statistics #1 full
@@ -2844,10 +2844,10 @@ icon
 numPvs 8
 numDsps 4
 displayFileName {
-  0 adl/NDStats.edl
-  1 adl/NDTimeSeries.edl
-  2 adl/NDTimeSeries.edl
-  3 adl/NDTimeSeriesAll.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStats.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  2 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  3 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeriesAll.edl
 }
 menuLabel {
   0 Statistics #1 full
@@ -2882,10 +2882,10 @@ icon
 numPvs 8
 numDsps 4
 displayFileName {
-  0 adl/NDStats.edl
-  1 adl/NDTimeSeries.edl
-  2 adl/NDTimeSeries.edl
-  3 adl/NDTimeSeriesAll.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStats.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  2 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  3 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeriesAll.edl
 }
 menuLabel {
   0 Statistics #1 full
@@ -2920,10 +2920,10 @@ icon
 numPvs 8
 numDsps 4
 displayFileName {
-  0 adl/NDStats.edl
-  1 adl/NDTimeSeries.edl
-  2 adl/NDTimeSeries.edl
-  3 adl/NDTimeSeriesAll.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStats.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  2 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  3 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeriesAll.edl
 }
 menuLabel {
   0 Statistics #1 full
@@ -2958,10 +2958,10 @@ icon
 numPvs 8
 numDsps 4
 displayFileName {
-  0 adl/NDStats.edl
-  1 adl/NDTimeSeries.edl
-  2 adl/NDTimeSeries.edl
-  3 adl/NDTimeSeriesAll.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStats.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  2 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeries.edl
+  3 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTimeSeriesAll.edl
 }
 menuLabel {
   0 Statistics #1 full

--- a/ADApp/op/edl/autoconvert/commonPlugins.edl
+++ b/ADApp/op/edl/autoconvert/commonPlugins.edl
@@ -5101,7 +5101,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDStdArrays.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStdArrays.edl
 }
 menuLabel {
   0 image1:
@@ -5131,7 +5131,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDProcess.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDProcess.edl
 }
 menuLabel {
   0 Proc1:
@@ -5161,7 +5161,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDTransform.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDTransform.edl
 }
 menuLabel {
   0 Trans1:
@@ -5191,7 +5191,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDColorConvert.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDColorConvert.edl
 }
 menuLabel {
   0 CC1:
@@ -5221,7 +5221,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDColorConvert.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDColorConvert.edl
 }
 menuLabel {
   0 CC2:
@@ -5251,7 +5251,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDOverlay.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDOverlay.edl
 }
 menuLabel {
   0 Over1:
@@ -5281,7 +5281,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDROI.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDROI.edl
 }
 menuLabel {
   0 ROI1:
@@ -5311,7 +5311,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDROI.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDROI.edl
 }
 menuLabel {
   0 ROI2:
@@ -5341,7 +5341,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDROI.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDROI.edl
 }
 menuLabel {
   0 ROI3:
@@ -5371,7 +5371,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDROI.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDROI.edl
 }
 menuLabel {
   0 ROI4:
@@ -5401,7 +5401,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDStats.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStats.edl
 }
 menuLabel {
   0 Stats1:
@@ -5431,7 +5431,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDStats.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStats.edl
 }
 menuLabel {
   0 Stats2:
@@ -5461,7 +5461,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDStats.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStats.edl
 }
 menuLabel {
   0 Stats3:
@@ -5491,7 +5491,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDStats.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStats.edl
 }
 menuLabel {
   0 Stats4:
@@ -5561,7 +5561,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDStats.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDStats.edl
 }
 menuLabel {
   0 Stats5:
@@ -5631,7 +5631,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDROIStat.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDROIStat.edl
 }
 menuLabel {
   0 ROI Statistics #1
@@ -5914,7 +5914,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDFileNetCDF.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDFileNetCDF.edl
 }
 menuLabel {
   0 netCDF1:
@@ -5944,7 +5944,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDFileTIFF.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDFileTIFF.edl
 }
 menuLabel {
   0 TIFF1:
@@ -5974,7 +5974,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDFileJPEG.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDFileJPEG.edl
 }
 menuLabel {
   0 JPEG1:
@@ -6004,7 +6004,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDFileNexus.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDFileNexus.edl
 }
 menuLabel {
   0 Nexus1:
@@ -6034,7 +6034,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDFileMagick.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDFileMagick.edl
 }
 menuLabel {
   0 Magick1:
@@ -6064,7 +6064,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDFileHDF5.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDFileHDF5.edl
 }
 menuLabel {
   0 HDF1:
@@ -6152,7 +6152,7 @@ buttonLabel "More"
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/NDCircularBuff.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDCircularBuff.edl
 }
 menuLabel {
   0 CB1:
@@ -6227,8 +6227,8 @@ buttonLabel "More"
 numPvs 4
 numDsps 2
 displayFileName {
-  0 adl/NDPluginAttribute.edl
-  1 adl/NDPluginAttribute8.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDPluginAttribute.edl
+  1 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/NDPluginAttribute8.edl
 }
 menuLabel {
   0 Attr1:

--- a/ADApp/op/edl/autoconvert/simDetector.edl
+++ b/ADApp/op/edl/autoconvert/simDetector.edl
@@ -1204,7 +1204,7 @@ icon
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/simDetectorSetup.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/simDetectorSetup.edl
 }
 menuLabel {
   0 Simulation setup

--- a/ADApp/op/edl/autoconvert/simDetectorSetup.edl
+++ b/ADApp/op/edl/autoconvert/simDetectorSetup.edl
@@ -1441,7 +1441,7 @@ icon
 numPvs 2
 numDsps 1
 displayFileName {
-  0 adl/ADBase.edl
+  0 /home/oxygen/MOONEY/epics/git/areaDetector/ADCore/ADApp/op/adl/ADBase.edl
 }
 menuLabel {
   0 Detector control

--- a/ADApp/op/opi/autoconvert/ADAttrFile.opi
+++ b/ADApp/op/opi/autoconvert/ADAttrFile.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7fff</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-7b38</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -36,7 +36,7 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7ffe</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7b37</wuid>
     <scripts />
     <height>60</height>
     <name>Grouping Container</name>
@@ -78,7 +78,7 @@
       <line_color>
         <color name="Gray_14" red="0" green="0" blue="0" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7ffa</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7b33</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -133,7 +133,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7ffd</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7b36</wuid>
       <scripts />
       <height>21</height>
       <name>Grouping Container</name>
@@ -175,7 +175,7 @@ $(pv_value)</tooltip>
         <line_color>
           <color red="128" green="0" blue="255" />
         </line_color>
-        <wuid>12e5a6d8:14c334c9085:-7ffc</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7b35</wuid>
         <bg_gradient_color>
           <color red="255" green="255" blue="255" />
         </bg_gradient_color>
@@ -229,7 +229,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7ffb</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7b34</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -270,7 +270,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7ff9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7b32</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -339,7 +339,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7ff8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7b31</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>

--- a/ADApp/op/opi/autoconvert/ADBase.opi
+++ b/ADApp/op/opi/autoconvert/ADBase.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7fee</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-7b27</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -36,7 +36,7 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7fed</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7b26</wuid>
     <scripts />
     <height>26</height>
     <name>Grouping Container</name>
@@ -78,7 +78,7 @@
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7fec</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7b25</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -131,7 +131,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7feb</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7b24</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>25</height>
@@ -175,7 +175,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7fea</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7b23</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -216,7 +216,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7fe9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7b22</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -257,7 +257,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7fe8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7b21</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -298,7 +298,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7fe7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7b20</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -339,7 +339,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7fe6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7b1f</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -380,7 +380,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7fe5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7b1e</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -421,7 +421,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7fe4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7b1d</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -462,7 +462,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7fe3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7b1c</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>

--- a/ADApp/op/opi/autoconvert/ADBuffers.opi
+++ b/ADApp/op/opi/autoconvert/ADBuffers.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7fbf</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-7af8</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7fb0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7ae9</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -93,7 +93,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7fbe</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7af7</wuid>
     <scripts />
     <height>21</height>
     <name>Grouping Container</name>
@@ -135,7 +135,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7fbd</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7af6</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -191,7 +191,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7fb9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7af2</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -229,7 +229,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7fb8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7af1</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -272,7 +272,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7fb7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7af0</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -323,7 +323,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7fb6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7aef</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -373,7 +373,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7fbc</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7af5</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -416,7 +416,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7fbb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7af4</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -467,7 +467,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7fba</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7af3</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -516,7 +516,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7fb5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7aee</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -559,7 +559,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7fb4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7aed</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -610,7 +610,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7fb3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7aec</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -660,7 +660,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7fb2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7aeb</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -702,7 +702,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7fb1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7aea</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -743,7 +743,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7faf</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7ae8</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>

--- a/ADApp/op/opi/autoconvert/ADCollect.opi
+++ b/ADApp/op/opi/autoconvert/ADCollect.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7f9c</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-7ad5</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7f9b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7ad4</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -93,7 +93,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7f9a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7ad3</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -131,7 +131,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7f99</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ad2</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -200,7 +200,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f98</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ad1</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -236,7 +236,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f97</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ad0</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -288,7 +288,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7f96</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7acf</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -326,7 +326,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7f95</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ace</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -395,7 +395,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f94</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7acd</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -431,7 +431,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f93</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7acc</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -483,7 +483,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7f92</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7acb</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -521,7 +521,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7f91</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7aca</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -590,7 +590,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f90</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ac9</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -626,7 +626,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f8f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ac8</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -678,7 +678,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7f8e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7ac7</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -718,7 +718,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f8d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ac6</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -767,7 +767,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7f8c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ac5</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -811,7 +811,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7f8b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7ac4</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -849,7 +849,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7f8a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ac3</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -918,7 +918,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f89</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ac2</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -954,7 +954,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f88</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ac1</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1006,7 +1006,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7f87</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7ac0</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -1044,7 +1044,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7f86</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7abf</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1086,7 +1086,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7f85</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7abe</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1130,7 +1130,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f84</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7abd</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1182,7 +1182,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7f83</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7abc</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -1220,7 +1220,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7f82</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7abb</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1262,7 +1262,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7f81</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7aba</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1306,7 +1306,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f80</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ab9</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1358,7 +1358,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7f7f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7ab8</wuid>
     <scripts />
     <height>40</height>
     <name>Grouping Container</name>
@@ -1396,7 +1396,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7f7e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ab7</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1447,7 +1447,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7f7d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ab6</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1498,7 +1498,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7f7c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ab5</wuid>
       <scripts />
       <height>20</height>
       <style>1</style>
@@ -1551,7 +1551,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7f7b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ab4</wuid>
       <scripts />
       <height>20</height>
       <style>1</style>
@@ -1604,7 +1604,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7f7a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ab3</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1648,7 +1648,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7f79</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7ab2</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -1686,7 +1686,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7f78</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ab1</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1729,7 +1729,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f77</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7ab0</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1781,7 +1781,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7f76</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7aaf</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -1819,7 +1819,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7f75</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7aae</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1862,7 +1862,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f74</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7aad</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1914,7 +1914,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7f70</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7aa9</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -1952,7 +1952,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7f6f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7aa8</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1995,7 +1995,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f6e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7aa7</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2047,7 +2047,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7f6d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7aa6</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -2085,7 +2085,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7f6c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7aa5</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2127,7 +2127,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7f6b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7aa4</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -2171,7 +2171,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f6a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7aa3</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2223,7 +2223,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7f67</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7aa0</wuid>
     <scripts />
     <height>21</height>
     <name>Grouping Container</name>
@@ -2265,7 +2265,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7f66</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7a9f</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -2347,7 +2347,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7f73</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7aac</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -2381,7 +2381,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7f72</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7aab</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2424,7 +2424,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7f71</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7aaa</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2473,7 +2473,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7f69</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7aa2</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2516,7 +2516,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7f68</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7aa1</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2565,7 +2565,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7f65</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a9e</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>

--- a/ADApp/op/opi/autoconvert/ADDriverFile.opi
+++ b/ADApp/op/opi/autoconvert/ADDriverFile.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7f2b</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-7a64</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -36,7 +36,7 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7f2a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a63</wuid>
     <scripts />
     <height>60</height>
     <name>Grouping Container</name>
@@ -78,7 +78,7 @@
       <line_color>
         <color name="Gray_14" red="0" green="0" blue="0" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7f25</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7a5e</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -133,7 +133,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7f29</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7a62</wuid>
       <scripts />
       <height>21</height>
       <name>Grouping Container</name>
@@ -173,7 +173,7 @@ $(pv_value)</tooltip>
           <include_parent_macros>true</include_parent_macros>
         </macros>
         <visible>true</visible>
-        <wuid>12e5a6d8:14c334c9085:-7f28</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7a61</wuid>
         <scripts />
         <height>21</height>
         <name>Grouping Container</name>
@@ -215,7 +215,7 @@ $(pv_value)</tooltip>
           <line_color>
             <color red="128" green="0" blue="255" />
           </line_color>
-          <wuid>12e5a6d8:14c334c9085:-7f27</wuid>
+          <wuid>-1ee33d7e:14c80d1e20e:-7a60</wuid>
           <bg_gradient_color>
             <color red="255" green="255" blue="255" />
           </bg_gradient_color>
@@ -269,7 +269,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7f26</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7a5f</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -311,7 +311,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7f24</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7a5d</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -353,7 +353,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7f23</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7a5c</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>

--- a/ADApp/op/opi/autoconvert/ADEpicsShutter.opi
+++ b/ADApp/op/opi/autoconvert/ADEpicsShutter.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7f18</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-7a51</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7f17</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a50</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -95,7 +95,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7f16</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a4f</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -150,7 +150,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7f0c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a45</wuid>
     <scripts />
     <height>170</height>
     <name>Grouping Container</name>
@@ -216,7 +216,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f0b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7a44</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -278,7 +278,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f0a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7a43</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -340,7 +340,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f09</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7a42</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -402,7 +402,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f08</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7a41</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -464,7 +464,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f07</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7a40</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -526,7 +526,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f06</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7a3f</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -588,7 +588,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7f05</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7a3e</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -623,7 +623,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7f15</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a4e</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -664,7 +664,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7f14</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a4d</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -705,7 +705,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7f13</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a4c</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -746,7 +746,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7f12</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a4b</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -787,7 +787,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7f11</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a4a</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -828,7 +828,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7f10</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a49</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -869,7 +869,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7f0f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a48</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -910,7 +910,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7f0e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a47</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -951,7 +951,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7f0d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a46</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>

--- a/ADApp/op/opi/autoconvert/ADPlugins.opi
+++ b/ADApp/op/opi/autoconvert/ADPlugins.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7eef</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-7a28</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7eed</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a26</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -95,7 +95,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7eec</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a25</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -148,7 +148,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7eee</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a27</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>40</height>
@@ -189,7 +189,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7eeb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a24</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -230,7 +230,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7eea</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a23</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -271,7 +271,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7ee9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a22</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -312,7 +312,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7ee8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a21</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -353,7 +353,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7ee7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a20</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -395,7 +395,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7ee6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a1f</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -509,7 +509,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7ee5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a1e</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -611,7 +611,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7ee4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a1d</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -703,7 +703,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7ee3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a1c</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -864,7 +864,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7ee2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a1b</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>

--- a/ADApp/op/opi/autoconvert/ADReadout.opi
+++ b/ADApp/op/opi/autoconvert/ADReadout.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7ed2</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-7a0b</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7ed1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a0a</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -95,7 +95,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7ed0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a09</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -150,7 +150,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7ec7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a00</wuid>
     <scripts />
     <height>40</height>
     <name>Grouping Container</name>
@@ -190,7 +190,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7ec6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79ff</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -267,7 +267,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7ec5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79fe</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -329,7 +329,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7ec4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79fd</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -365,7 +365,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7ec3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79fc</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -417,7 +417,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7ec0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79f9</wuid>
     <scripts />
     <height>40</height>
     <name>Grouping Container</name>
@@ -483,7 +483,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7ebf</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79f8</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -545,7 +545,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7ebe</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79f7</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -581,7 +581,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7ebd</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79f6</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -632,7 +632,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7ebc</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79f5</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -684,7 +684,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7eb6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79ef</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -724,7 +724,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7eb5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79ee</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -801,7 +801,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7eb4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79ed</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -835,7 +835,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7eb3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79ec</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -879,7 +879,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7eb2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79eb</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -917,7 +917,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7eb1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79ea</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -959,7 +959,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7eb0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79e9</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1003,7 +1003,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7eaf</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79e8</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1053,7 +1053,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7ecf</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a08</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1094,7 +1094,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7ece</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a07</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1135,7 +1135,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7ecd</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a06</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1204,7 +1204,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7ecc</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a05</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -1266,7 +1266,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7ecb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a04</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -1302,7 +1302,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7eca</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a03</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1353,7 +1353,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7ec9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a02</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1402,7 +1402,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7ec8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7a01</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1443,7 +1443,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7ec2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79fb</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1484,7 +1484,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7ec1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79fa</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1525,7 +1525,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7ebb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79f4</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1568,7 +1568,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7eba</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79f3</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1619,7 +1619,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7eb9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79f2</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1668,7 +1668,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7eb8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79f1</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1711,7 +1711,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7eb7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79f0</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1762,7 +1762,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7eae</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79e7</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1813,7 +1813,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7ead</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79e6</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1862,7 +1862,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7eac</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79e5</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1904,7 +1904,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7eab</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79e4</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -1947,7 +1947,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7eaa</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79e3</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -1989,7 +1989,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7ea9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79e2</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2031,7 +2031,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7ea8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79e1</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -2075,7 +2075,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7ea7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79e0</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2124,7 +2124,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7ea6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79df</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2167,7 +2167,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7ea5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79de</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2218,7 +2218,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7ea4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79dd</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />

--- a/ADApp/op/opi/autoconvert/ADSetup.opi
+++ b/ADApp/op/opi/autoconvert/ADSetup.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7e73</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-79ac</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7e72</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79ab</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -95,7 +95,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7e71</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79aa</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -152,7 +152,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7e70</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79a9</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -207,7 +207,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7e6e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79a7</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -245,7 +245,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7e6d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79a6</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>18</height>
@@ -286,7 +286,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7e6c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79a5</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -330,7 +330,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7e6b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79a4</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -368,7 +368,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7e6a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79a3</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -411,7 +411,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7e69</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-79a2</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -461,7 +461,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e6f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79a8</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -502,7 +502,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e68</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79a1</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -544,7 +544,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7e67</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-79a0</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -604,7 +604,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e66</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-799f</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -647,7 +647,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7e65</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-799e</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -696,7 +696,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e64</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-799d</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -737,7 +737,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7e63</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-799c</wuid>
     <scripts />
     <height>20</height>
     <style>1</style>
@@ -790,7 +790,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7e62</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-799b</wuid>
     <scripts />
     <height>20</height>
     <style>1</style>
@@ -843,7 +843,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e61</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-799a</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -894,7 +894,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e60</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7999</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -945,7 +945,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e5f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7998</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -988,7 +988,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7e5e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7997</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />

--- a/ADApp/op/opi/autoconvert/ADShutter.opi
+++ b/ADApp/op/opi/autoconvert/ADShutter.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7e46</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-797f</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7e45</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-797e</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -95,7 +95,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7e44</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-797d</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -148,7 +148,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e43</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-797c</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -189,7 +189,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e42</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-797b</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -231,7 +231,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7e41</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-797a</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -273,7 +273,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e40</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7979</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -314,7 +314,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7e3f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7978</wuid>
     <scripts />
     <height>20</height>
     <style>1</style>
@@ -367,7 +367,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7e3e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7977</wuid>
     <scripts />
     <height>20</height>
     <style>1</style>
@@ -420,7 +420,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e3d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7976</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -463,7 +463,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7e3c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7975</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -540,7 +540,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7e3b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7974</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -574,7 +574,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e3a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7973</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -615,7 +615,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e39</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7972</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -684,7 +684,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7e38</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7971</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -719,7 +719,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7e37</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7970</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -770,7 +770,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e36</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-796f</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -811,7 +811,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e35</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-796e</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -854,7 +854,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7e34</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-796d</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />

--- a/ADApp/op/opi/autoconvert/ADTop.opi
+++ b/ADApp/op/opi/autoconvert/ADTop.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7e1f</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-7958</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -36,7 +36,7 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7e17</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7950</wuid>
     <scripts />
     <height>345</height>
     <name>Grouping Container</name>
@@ -75,7 +75,7 @@
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7e16</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-794f</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -158,7 +158,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7e15</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-794e</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -200,7 +200,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7e14</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-794d</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -283,7 +283,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7e13</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-794c</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -325,7 +325,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7e12</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-794b</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -388,7 +388,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7e11</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-794a</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -430,7 +430,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7e10</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7949</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -493,7 +493,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7e0f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7948</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -535,7 +535,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7e0e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7947</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -598,7 +598,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7e0d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7946</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -640,7 +640,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7e0c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7945</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -703,7 +703,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7e0b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7944</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -745,7 +745,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7e0a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7943</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -808,7 +808,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7e09</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7942</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -850,7 +850,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7e08</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7941</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -913,7 +913,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7e07</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7940</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -955,7 +955,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7e06</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-793f</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1018,7 +1018,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7e05</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-793e</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1060,7 +1060,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7e04</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-793d</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1123,7 +1123,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7e03</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-793c</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1165,7 +1165,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7e02</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-793b</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1238,7 +1238,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7e01</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-793a</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1280,7 +1280,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7e00</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7939</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1343,7 +1343,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7dff</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7938</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1385,7 +1385,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7dfe</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7937</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1448,7 +1448,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7dfd</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7936</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1490,7 +1490,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7dfc</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7935</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1553,7 +1553,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7dfb</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7934</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1597,7 +1597,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7dfa</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7933</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -1636,7 +1636,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7df9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7932</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1699,7 +1699,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7df8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7931</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1741,7 +1741,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e1e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7957</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>31</height>
@@ -1783,7 +1783,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7e1d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7956</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -1846,7 +1846,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e1c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7955</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1888,7 +1888,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7e1b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7954</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -1981,7 +1981,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e1a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7953</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2023,7 +2023,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7e19</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7952</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -2086,7 +2086,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7e18</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7951</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2128,7 +2128,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7df7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7930</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -2191,7 +2191,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7df6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-792f</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>

--- a/ADApp/op/opi/autoconvert/NDColorConvert.opi
+++ b/ADApp/op/opi/autoconvert/NDColorConvert.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7d38</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-7871</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7d37</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7870</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -93,7 +93,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7d35</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-786e</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -134,7 +134,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7d34</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-786d</wuid>
     <scripts />
     <height>60</height>
     <name>Grouping Container</name>
@@ -176,7 +176,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color name="Gray_14" red="0" green="0" blue="0" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7d33</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-786c</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -231,7 +231,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7d32</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-786b</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -269,7 +269,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7d31</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-786a</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -311,7 +311,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>true</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-7d30</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7869</wuid>
         <scripts />
         <height>20</height>
         <name>Menu Button</name>
@@ -355,7 +355,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7d2f</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7868</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -405,7 +405,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7d2e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7867</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -447,7 +447,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7d2d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7866</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -491,7 +491,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7d2c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7865</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -541,7 +541,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7d36</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-786f</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>25</height>

--- a/ADApp/op/opi/autoconvert/NDFile.opi
+++ b/ADApp/op/opi/autoconvert/NDFile.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7d1b</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-7854</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -36,7 +36,7 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7d1a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7853</wuid>
     <scripts />
     <height>26</height>
     <name>Grouping Container</name>
@@ -78,7 +78,7 @@
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7d19</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7852</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -131,7 +131,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7d18</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7851</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>25</height>
@@ -175,7 +175,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7d17</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7850</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -213,7 +213,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7d16</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-784f</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -256,7 +256,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7d15</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-784e</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -306,7 +306,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7d14</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-784d</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -351,7 +351,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7d13</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-784c</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>

--- a/ADApp/op/opi/autoconvert/NDFileHDF5.opi
+++ b/ADApp/op/opi/autoconvert/NDFileHDF5.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7c7d</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-77b6</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -36,7 +36,7 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7c7c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-77b5</wuid>
     <scripts />
     <height>26</height>
     <name>Grouping Container</name>
@@ -78,7 +78,7 @@
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7c7b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-77b4</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -131,7 +131,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7c7a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-77b3</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>25</height>
@@ -175,7 +175,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7c79</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-77b2</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -216,7 +216,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7c78</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-77b1</wuid>
     <scripts />
     <height>320</height>
     <name>Grouping Container</name>
@@ -258,7 +258,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color name="Gray_14" red="0" green="0" blue="0" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7c75</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-77ae</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -313,7 +313,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c74</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-77ad</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -351,7 +351,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c73</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-77ac</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -420,7 +420,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c72</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-77ab</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -456,7 +456,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c71</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-77aa</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -508,7 +508,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c70</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-77a9</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -546,7 +546,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c6f</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-77a8</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -615,7 +615,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c6e</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-77a7</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -651,7 +651,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c6d</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-77a6</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -703,7 +703,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c6c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-77a5</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -741,7 +741,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c6b</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-77a4</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -810,7 +810,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c6a</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-77a3</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -846,7 +846,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c69</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-77a2</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -898,7 +898,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c68</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-77a1</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -936,7 +936,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c67</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-77a0</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -978,7 +978,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>true</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-7c66</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-779f</wuid>
         <scripts />
         <height>20</height>
         <name>Menu Button</name>
@@ -1022,7 +1022,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c65</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-779e</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1074,7 +1074,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c64</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-779d</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -1112,7 +1112,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c63</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-779c</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -1154,7 +1154,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>true</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-7c62</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-779b</wuid>
         <scripts />
         <height>20</height>
         <name>Menu Button</name>
@@ -1198,7 +1198,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c61</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-779a</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1250,7 +1250,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c60</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7799</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -1316,7 +1316,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c5f</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7798</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -1350,7 +1350,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c5e</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7797</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -1393,7 +1393,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c5d</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7796</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1445,7 +1445,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c5c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7795</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -1485,7 +1485,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c5b</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7794</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1534,7 +1534,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c5a</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7793</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -1576,7 +1576,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>true</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-7c59</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7792</wuid>
         <scripts />
         <height>20</height>
         <name>Menu Button</name>
@@ -1621,7 +1621,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c58</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7791</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -1661,7 +1661,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c57</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7790</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1710,7 +1710,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c56</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-778f</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -1754,7 +1754,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c55</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-778e</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -1792,7 +1792,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c54</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-778d</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -1835,7 +1835,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c53</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-778c</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1887,7 +1887,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c52</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-778b</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -1925,7 +1925,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c51</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-778a</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -1994,7 +1994,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c50</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7789</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -2030,7 +2030,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c4f</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7788</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2082,7 +2082,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c4e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7787</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -2120,7 +2120,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c4d</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7786</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2189,7 +2189,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c4c</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7785</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -2225,7 +2225,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c4b</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7784</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2277,7 +2277,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c4a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7783</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -2315,7 +2315,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c49</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7782</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2358,7 +2358,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c48</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7781</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2410,7 +2410,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c47</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7780</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -2448,7 +2448,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c46</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-777f</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2517,7 +2517,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c45</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-777e</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -2553,7 +2553,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c44</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-777d</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2605,7 +2605,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c43</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-777c</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -2643,7 +2643,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c42</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-777b</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2686,7 +2686,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c41</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-777a</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2738,7 +2738,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c40</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7779</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -2776,7 +2776,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c3f</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7778</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2845,7 +2845,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c3e</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7777</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -2881,7 +2881,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c3d</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7776</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2933,7 +2933,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c3c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7775</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -2971,7 +2971,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c3b</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7774</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -3014,7 +3014,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c3a</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7773</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -3066,7 +3066,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c39</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7772</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -3106,7 +3106,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c38</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7771</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -3155,7 +3155,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c37</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7770</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -3199,7 +3199,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c36</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-776f</wuid>
       <scripts />
       <height>43</height>
       <name>Grouping Container</name>
@@ -3239,7 +3239,7 @@ $(pv_value)</tooltip>
           <include_parent_macros>true</include_parent_macros>
         </macros>
         <visible>true</visible>
-        <wuid>12e5a6d8:14c334c9085:-7c34</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-776d</wuid>
         <scripts />
         <height>20</height>
         <name>Grouping Container</name>
@@ -3277,7 +3277,7 @@ $(pv_value)</tooltip>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <visible>true</visible>
           <vertical_alignment>1</vertical_alignment>
-          <wuid>12e5a6d8:14c334c9085:-7c33</wuid>
+          <wuid>-1ee33d7e:14c80d1e20e:-776c</wuid>
           <auto_size>false</auto_size>
           <scripts />
           <height>20</height>
@@ -3346,7 +3346,7 @@ $(pv_value)</tooltip>
           <minimum>-Infinity</minimum>
           <next_focus>0</next_focus>
           <show_units>false</show_units>
-          <wuid>12e5a6d8:14c334c9085:-7c32</wuid>
+          <wuid>-1ee33d7e:14c80d1e20e:-776b</wuid>
           <rotation_angle>0.0</rotation_angle>
           <style>0</style>
           <name>Text Input</name>
@@ -3383,7 +3383,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c35</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-776e</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -3433,7 +3433,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7c77</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-77b0</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -3476,7 +3476,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7c76</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-77af</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3528,7 +3528,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7c31</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-776a</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -3569,7 +3569,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7c30</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7769</wuid>
     <scripts />
     <height>160</height>
     <name>Grouping Container</name>
@@ -3611,7 +3611,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color name="Gray_14" red="0" green="0" blue="0" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7c2f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7768</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -3666,7 +3666,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c2e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7767</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -3704,7 +3704,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c2d</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7766</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -3773,7 +3773,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c2c</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7765</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -3809,7 +3809,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c2b</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7764</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -3861,7 +3861,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c2a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7763</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -3899,7 +3899,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c29</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7762</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -3968,7 +3968,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c28</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7761</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -4004,7 +4004,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c27</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7760</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -4056,7 +4056,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c26</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-775f</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -4094,7 +4094,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c25</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-775e</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -4163,7 +4163,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c24</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-775d</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -4199,7 +4199,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c23</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-775c</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -4251,7 +4251,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c22</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-775b</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -4289,7 +4289,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c21</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-775a</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -4358,7 +4358,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c20</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7759</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -4394,7 +4394,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c1f</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7758</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -4446,7 +4446,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c1e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7757</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -4484,7 +4484,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c1d</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7756</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -4553,7 +4553,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c1c</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7755</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -4589,7 +4589,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c1b</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7754</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -4641,7 +4641,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7c1a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7753</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -4679,7 +4679,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7c19</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7752</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -4748,7 +4748,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c18</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7751</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -4784,7 +4784,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7c17</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7750</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />

--- a/ADApp/op/opi/autoconvert/NDFileJPEG.opi
+++ b/ADApp/op/opi/autoconvert/NDFileJPEG.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7b68</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-758c</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -36,7 +36,7 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7b67</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-758b</wuid>
     <scripts />
     <height>26</height>
     <name>Grouping Container</name>
@@ -78,7 +78,7 @@
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7b66</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-758a</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -131,7 +131,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7b65</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7589</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>25</height>
@@ -175,7 +175,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7b64</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7588</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -216,7 +216,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7b63</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7587</wuid>
     <scripts />
     <height>22</height>
     <name>Grouping Container</name>
@@ -254,7 +254,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7b62</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7586</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -323,7 +323,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7b61</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7585</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -359,7 +359,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7b60</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7584</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -411,7 +411,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7b5f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7583</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>

--- a/ADApp/op/opi/autoconvert/NDFileMagick.opi
+++ b/ADApp/op/opi/autoconvert/NDFileMagick.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7b0d</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-7531</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -36,7 +36,7 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7b0c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7530</wuid>
     <scripts />
     <height>26</height>
     <name>Grouping Container</name>
@@ -78,7 +78,7 @@
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7b0b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-752f</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -131,7 +131,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7b0a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-752e</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>25</height>
@@ -175,7 +175,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7b09</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-752d</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -216,7 +216,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7b08</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-752c</wuid>
     <scripts />
     <height>72</height>
     <name>Grouping Container</name>
@@ -256,7 +256,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7b07</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-752b</wuid>
       <scripts />
       <height>72</height>
       <name>Grouping Container</name>
@@ -295,7 +295,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>true</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-7b06</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-752a</wuid>
         <scripts />
         <height>20</height>
         <name>Menu Button</name>
@@ -338,7 +338,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>true</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-7b05</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7529</wuid>
         <scripts />
         <height>20</height>
         <name>Menu Button</name>
@@ -408,7 +408,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7b04</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7528</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -445,7 +445,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7b03</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7527</wuid>
       <scripts />
       <height>70</height>
       <name>Grouping Container</name>
@@ -485,7 +485,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7b02</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7526</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -536,7 +536,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7b01</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7525</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -587,7 +587,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7b00</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7524</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -639,7 +639,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7aff</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7523</wuid>
       <scripts />
       <height>72</height>
       <name>Grouping Container</name>
@@ -677,7 +677,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7afe</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7522</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -718,7 +718,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7afd</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7521</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -759,7 +759,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7afc</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7520</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -804,7 +804,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7afb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-751f</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>

--- a/ADApp/op/opi/autoconvert/NDFileNetCDF.opi
+++ b/ADApp/op/opi/autoconvert/NDFileNetCDF.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7aa0</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-74c4</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -36,7 +36,7 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7a9f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-74c3</wuid>
     <scripts />
     <height>26</height>
     <name>Grouping Container</name>
@@ -78,7 +78,7 @@
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7a9e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-74c2</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -131,7 +131,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7a9d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-74c1</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>25</height>
@@ -175,7 +175,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7a9c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-74c0</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -216,7 +216,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7a9b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-74bf</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>

--- a/ADApp/op/opi/autoconvert/NDFileNexus.opi
+++ b/ADApp/op/opi/autoconvert/NDFileNexus.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7a4d</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-7471</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -36,7 +36,7 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7a4c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7470</wuid>
     <scripts />
     <height>26</height>
     <name>Grouping Container</name>
@@ -78,7 +78,7 @@
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7a4b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-746f</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -131,7 +131,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7a4a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-746e</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>25</height>
@@ -175,7 +175,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7a49</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-746d</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -216,7 +216,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7a48</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-746c</wuid>
     <scripts />
     <height>110</height>
     <name>Grouping Container</name>
@@ -258,7 +258,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7a47</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-746b</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -325,7 +325,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color name="Gray_14" red="0" green="0" blue="0" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7a46</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-746a</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -380,7 +380,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7a45</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7469</wuid>
       <scripts />
       <height>91</height>
       <name>Grouping Container</name>
@@ -446,7 +446,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7a44</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7468</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -482,7 +482,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7a43</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7467</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -559,7 +559,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7a42</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7466</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -595,7 +595,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7a41</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7465</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -644,7 +644,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7a40</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7464</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -685,7 +685,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7a3f</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7463</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -730,7 +730,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7a3e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7462</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>

--- a/ADApp/op/opi/autoconvert/NDFileNull.opi
+++ b/ADApp/op/opi/autoconvert/NDFileNull.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-79e6</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-740a</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -36,7 +36,7 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-79e5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7409</wuid>
     <scripts />
     <height>26</height>
     <name>Grouping Container</name>
@@ -78,7 +78,7 @@
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-79e4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7408</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -131,7 +131,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-79e3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7407</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>25</height>
@@ -175,7 +175,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-79e2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7406</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -216,7 +216,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-79e1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7405</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>

--- a/ADApp/op/opi/autoconvert/NDFileTIFF.opi
+++ b/ADApp/op/opi/autoconvert/NDFileTIFF.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7993</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-73b7</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -36,7 +36,7 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7992</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-73b6</wuid>
     <scripts />
     <height>26</height>
     <name>Grouping Container</name>
@@ -78,7 +78,7 @@
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7991</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-73b5</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -131,7 +131,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7990</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-73b4</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>25</height>
@@ -175,7 +175,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-798f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-73b3</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -216,7 +216,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-798e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-73b2</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>

--- a/ADApp/op/opi/autoconvert/NDOverlay.opi
+++ b/ADApp/op/opi/autoconvert/NDOverlay.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7940</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-7364</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-793f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7363</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -93,7 +93,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-793d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7361</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -134,7 +134,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-793c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7360</wuid>
     <scripts />
     <height>85</height>
     <name>Grouping Container</name>
@@ -176,7 +176,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color name="Gray_14" red="0" green="0" blue="0" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-793b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-735f</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -230,7 +230,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-793a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-735e</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -345,7 +345,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7939</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-735d</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -387,7 +387,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7938</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-735c</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -462,7 +462,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7937</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-735b</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -503,7 +503,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7936</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-735a</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -545,7 +545,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-793e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7362</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>25</height>

--- a/ADApp/op/opi/autoconvert/NDOverlay8.opi
+++ b/ADApp/op/opi/autoconvert/NDOverlay8.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7927</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-734b</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7926</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-734a</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -93,7 +93,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7916</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-733a</wuid>
     <scripts />
     <height>68</height>
     <name>Grouping Container</name>
@@ -132,7 +132,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7915</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7339</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -176,7 +176,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7914</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7338</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -253,7 +253,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7913</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7337</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -289,7 +289,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7912</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7336</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -339,7 +339,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7911</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7335</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -383,7 +383,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7910</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7334</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -433,7 +433,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-790f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7333</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -477,7 +477,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-790e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7332</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -554,7 +554,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-790d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7331</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -590,7 +590,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-790c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7330</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -667,7 +667,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-790b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-732f</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -703,7 +703,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-790a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-732e</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -789,7 +789,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7909</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-732d</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -867,7 +867,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7908</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-732c</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -903,7 +903,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7907</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-732b</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -989,7 +989,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7906</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-732a</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -1067,7 +1067,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7905</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7329</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1103,7 +1103,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7904</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7328</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1189,7 +1189,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7903</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7327</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -1267,7 +1267,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7902</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7326</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1303,7 +1303,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7901</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7325</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1389,7 +1389,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7900</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7324</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -1467,7 +1467,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78ff</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7323</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1503,7 +1503,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78fe</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7322</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1580,7 +1580,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78fd</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7321</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1616,7 +1616,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78fc</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7320</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1665,7 +1665,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-78fb</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-731f</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1707,7 +1707,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-78fa</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-731e</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1762,7 +1762,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-78f9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-731d</wuid>
     <scripts />
     <height>68</height>
     <name>Grouping Container</name>
@@ -1801,7 +1801,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-78f8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-731c</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -1845,7 +1845,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78f7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-731b</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1922,7 +1922,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78f6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-731a</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1958,7 +1958,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78f5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7319</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2008,7 +2008,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-78f4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7318</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -2052,7 +2052,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78f3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7317</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2102,7 +2102,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-78f2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7316</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -2146,7 +2146,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78f1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7315</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2223,7 +2223,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78f0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7314</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -2259,7 +2259,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78ef</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7313</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2336,7 +2336,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78ee</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7312</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -2372,7 +2372,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78ed</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7311</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2458,7 +2458,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-78ec</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7310</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -2536,7 +2536,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78eb</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-730f</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -2572,7 +2572,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78ea</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-730e</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2658,7 +2658,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-78e9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-730d</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -2736,7 +2736,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78e8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-730c</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -2772,7 +2772,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78e7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-730b</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2858,7 +2858,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-78e6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-730a</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -2936,7 +2936,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78e5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7309</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -2972,7 +2972,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78e4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7308</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3058,7 +3058,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-78e3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7307</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -3136,7 +3136,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78e2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7306</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -3172,7 +3172,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78e1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7305</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3249,7 +3249,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78e0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7304</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -3285,7 +3285,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78df</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7303</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3334,7 +3334,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-78de</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7302</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -3376,7 +3376,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-78dd</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7301</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -3431,7 +3431,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-78dc</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7300</wuid>
     <scripts />
     <height>68</height>
     <name>Grouping Container</name>
@@ -3470,7 +3470,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-78db</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72ff</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -3514,7 +3514,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78da</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72fe</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3591,7 +3591,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78d9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72fd</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -3627,7 +3627,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78d8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72fc</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3677,7 +3677,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-78d7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72fb</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -3721,7 +3721,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78d6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72fa</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3771,7 +3771,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-78d5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72f9</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -3815,7 +3815,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78d4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72f8</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3892,7 +3892,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78d3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72f7</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -3928,7 +3928,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78d2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72f6</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4005,7 +4005,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78d1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72f5</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -4041,7 +4041,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78d0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72f4</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4127,7 +4127,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-78cf</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72f3</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -4205,7 +4205,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78ce</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72f2</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -4241,7 +4241,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78cd</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72f1</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4327,7 +4327,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-78cc</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72f0</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -4405,7 +4405,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78cb</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72ef</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -4441,7 +4441,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78ca</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72ee</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4527,7 +4527,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-78c9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72ed</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -4605,7 +4605,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78c8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72ec</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -4641,7 +4641,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78c7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72eb</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4727,7 +4727,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-78c6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72ea</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -4805,7 +4805,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78c5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72e9</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -4841,7 +4841,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78c4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72e8</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4918,7 +4918,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78c3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72e7</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -4954,7 +4954,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78c2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72e6</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -5003,7 +5003,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-78c1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72e5</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -5045,7 +5045,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-78c0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72e4</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -5100,7 +5100,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-78bf</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-72e3</wuid>
     <scripts />
     <height>68</height>
     <name>Grouping Container</name>
@@ -5139,7 +5139,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-78be</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72e2</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -5183,7 +5183,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78bd</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72e1</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -5260,7 +5260,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78bc</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72e0</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -5296,7 +5296,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78bb</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72df</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -5346,7 +5346,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-78ba</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72de</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -5390,7 +5390,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78b9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72dd</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -5440,7 +5440,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-78b8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72dc</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -5484,7 +5484,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78b7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72db</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -5561,7 +5561,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78b6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72da</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -5597,7 +5597,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78b5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72d9</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -5674,7 +5674,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78b4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72d8</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -5710,7 +5710,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78b3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72d7</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -5796,7 +5796,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-78b2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72d6</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -5874,7 +5874,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78b1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72d5</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -5910,7 +5910,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78b0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72d4</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -5996,7 +5996,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-78af</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72d3</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -6074,7 +6074,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78ae</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72d2</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -6110,7 +6110,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78ad</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72d1</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -6196,7 +6196,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-78ac</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72d0</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -6274,7 +6274,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78ab</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72cf</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -6310,7 +6310,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78aa</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72ce</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -6396,7 +6396,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-78a9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72cd</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -6474,7 +6474,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78a8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72cc</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -6510,7 +6510,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78a7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72cb</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -6587,7 +6587,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78a6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72ca</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -6623,7 +6623,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78a5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72c9</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -6672,7 +6672,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-78a4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72c8</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -6714,7 +6714,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-78a3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72c7</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -6769,7 +6769,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-78a2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-72c6</wuid>
     <scripts />
     <height>68</height>
     <name>Grouping Container</name>
@@ -6808,7 +6808,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-78a1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72c5</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -6852,7 +6852,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-78a0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72c4</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -6929,7 +6929,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-789f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72c3</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -6965,7 +6965,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-789e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72c2</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -7015,7 +7015,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-789d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72c1</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -7059,7 +7059,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-789c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72c0</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -7109,7 +7109,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-789b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72bf</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -7153,7 +7153,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-789a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72be</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -7230,7 +7230,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7899</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72bd</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -7266,7 +7266,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7898</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72bc</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -7343,7 +7343,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7897</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72bb</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -7379,7 +7379,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7896</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72ba</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -7465,7 +7465,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7895</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72b9</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -7543,7 +7543,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7894</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72b8</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -7579,7 +7579,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7893</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72b7</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -7665,7 +7665,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7892</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72b6</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -7743,7 +7743,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7891</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72b5</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -7779,7 +7779,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7890</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72b4</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -7865,7 +7865,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-788f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72b3</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -7943,7 +7943,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-788e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72b2</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -7979,7 +7979,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-788d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72b1</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -8065,7 +8065,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-788c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72b0</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -8143,7 +8143,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-788b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72af</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -8179,7 +8179,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-788a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72ae</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -8256,7 +8256,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7889</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72ad</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -8292,7 +8292,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7888</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72ac</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -8341,7 +8341,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7887</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72ab</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -8383,7 +8383,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7886</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72aa</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -8438,7 +8438,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7885</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-72a9</wuid>
     <scripts />
     <height>68</height>
     <name>Grouping Container</name>
@@ -8477,7 +8477,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7884</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72a8</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -8521,7 +8521,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7883</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72a7</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -8598,7 +8598,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7882</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72a6</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -8634,7 +8634,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7881</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72a5</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -8684,7 +8684,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7880</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72a4</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -8728,7 +8728,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-787f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72a3</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -8778,7 +8778,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-787e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72a2</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -8822,7 +8822,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-787d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72a1</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -8899,7 +8899,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-787c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-72a0</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -8935,7 +8935,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-787b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-729f</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -9012,7 +9012,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-787a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-729e</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -9048,7 +9048,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7879</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-729d</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -9134,7 +9134,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7878</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-729c</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -9212,7 +9212,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7877</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-729b</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -9248,7 +9248,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7876</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-729a</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -9334,7 +9334,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7875</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7299</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -9412,7 +9412,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7874</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7298</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -9448,7 +9448,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7873</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7297</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -9534,7 +9534,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7872</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7296</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -9612,7 +9612,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7871</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7295</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -9648,7 +9648,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7870</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7294</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -9734,7 +9734,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-786f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7293</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -9812,7 +9812,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-786e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7292</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -9848,7 +9848,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-786d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7291</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -9925,7 +9925,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-786c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7290</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -9961,7 +9961,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-786b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-728f</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -10010,7 +10010,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-786a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-728e</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -10052,7 +10052,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7869</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-728d</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -10107,7 +10107,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7868</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-728c</wuid>
     <scripts />
     <height>68</height>
     <name>Grouping Container</name>
@@ -10146,7 +10146,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7867</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-728b</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -10190,7 +10190,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7866</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-728a</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -10267,7 +10267,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7865</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7289</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -10303,7 +10303,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7864</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7288</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -10353,7 +10353,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7863</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7287</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -10397,7 +10397,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7862</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7286</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -10447,7 +10447,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7861</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7285</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -10491,7 +10491,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7860</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7284</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -10568,7 +10568,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-785f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7283</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -10604,7 +10604,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-785e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7282</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -10681,7 +10681,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-785d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7281</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -10717,7 +10717,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-785c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7280</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -10803,7 +10803,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-785b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-727f</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -10881,7 +10881,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-785a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-727e</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -10917,7 +10917,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7859</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-727d</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -11003,7 +11003,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7858</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-727c</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -11081,7 +11081,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7857</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-727b</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -11117,7 +11117,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7856</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-727a</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -11203,7 +11203,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7855</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7279</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -11281,7 +11281,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7854</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7278</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -11317,7 +11317,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7853</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7277</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -11403,7 +11403,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7852</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7276</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -11481,7 +11481,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7851</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7275</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -11517,7 +11517,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7850</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7274</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -11594,7 +11594,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-784f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7273</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -11630,7 +11630,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-784e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7272</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -11679,7 +11679,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-784d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7271</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -11721,7 +11721,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-784c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7270</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -11776,7 +11776,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-784b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-726f</wuid>
     <scripts />
     <height>68</height>
     <name>Grouping Container</name>
@@ -11815,7 +11815,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-784a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-726e</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -11859,7 +11859,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7849</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-726d</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -11936,7 +11936,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7848</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-726c</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -11972,7 +11972,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7847</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-726b</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -12022,7 +12022,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7846</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-726a</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -12066,7 +12066,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7845</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7269</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -12116,7 +12116,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7844</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7268</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -12160,7 +12160,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7843</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7267</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -12237,7 +12237,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7842</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7266</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -12273,7 +12273,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7841</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7265</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -12350,7 +12350,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7840</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7264</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -12386,7 +12386,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-783f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7263</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -12472,7 +12472,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-783e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7262</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -12550,7 +12550,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-783d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7261</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -12586,7 +12586,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-783c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7260</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -12672,7 +12672,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-783b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-725f</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -12750,7 +12750,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-783a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-725e</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -12786,7 +12786,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7839</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-725d</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -12872,7 +12872,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7838</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-725c</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -12950,7 +12950,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7837</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-725b</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -12986,7 +12986,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7836</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-725a</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -13072,7 +13072,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7835</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7259</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -13150,7 +13150,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7834</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7258</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -13186,7 +13186,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7833</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7257</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -13263,7 +13263,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7832</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7256</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -13299,7 +13299,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7831</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7255</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -13348,7 +13348,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7830</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7254</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -13390,7 +13390,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-782f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7253</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -13443,7 +13443,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7925</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7349</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>25</height>
@@ -13484,7 +13484,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7924</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7348</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -13525,7 +13525,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7923</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7347</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -13566,7 +13566,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7922</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7346</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -13607,7 +13607,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7921</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7345</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -13648,7 +13648,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7920</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7344</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -13689,7 +13689,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-791f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7343</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -13730,7 +13730,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-791e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7342</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -13771,7 +13771,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-791d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7341</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -13812,7 +13812,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-791c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7340</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -13853,7 +13853,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-791b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-733f</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -13894,7 +13894,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-791a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-733e</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -13935,7 +13935,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7919</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-733d</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -13976,7 +13976,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7918</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-733c</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -14017,7 +14017,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7917</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-733b</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>

--- a/ADApp/op/opi/autoconvert/NDOverlayN.opi
+++ b/ADApp/op/opi/autoconvert/NDOverlayN.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7734</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-7158</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7733</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7157</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -95,7 +95,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7732</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7156</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -150,7 +150,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7718</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-713c</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -189,7 +189,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7717</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-713b</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -231,7 +231,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7716</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-713a</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -275,7 +275,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7713</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7137</wuid>
     <scripts />
     <height>255</height>
     <name>Grouping Container</name>
@@ -317,7 +317,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color name="Gray_14" red="0" green="0" blue="0" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7701</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7125</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -372,7 +372,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-770f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7133</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -410,7 +410,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-770e</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7132</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -479,7 +479,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-770d</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7131</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -515,7 +515,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-770c</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7130</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -567,7 +567,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-770b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-712f</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -605,7 +605,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-770a</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-712e</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -674,7 +674,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7709</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-712d</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -711,7 +711,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7708</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-712c</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -749,7 +749,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7707</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-712b</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -818,7 +818,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7706</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-712a</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -854,7 +854,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7705</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7129</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -906,7 +906,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7704</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7128</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -944,7 +944,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7703</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7127</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -1013,7 +1013,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7702</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7126</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -1085,7 +1085,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7712</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7136</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -1172,7 +1172,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7711</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7135</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -1222,7 +1222,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7710</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7134</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1300,7 +1300,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7700</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7124</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -1350,7 +1350,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-76ff</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7123</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1419,7 +1419,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-76fe</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7122</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1455,7 +1455,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-76fd</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7121</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1532,7 +1532,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-76fc</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7120</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1566,7 +1566,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-76fb</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-711f</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1610,7 +1610,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-76fa</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-711e</wuid>
     <scripts />
     <height>255</height>
     <name>Grouping Container</name>
@@ -1652,7 +1652,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color name="Gray_14" red="0" green="0" blue="0" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-76f2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7116</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -1707,7 +1707,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-76f1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7115</wuid>
       <scripts />
       <height>70</height>
       <name>Grouping Container</name>
@@ -1782,7 +1782,7 @@ $(pv_value)</tooltip>
         <horizontal>false</horizontal>
         <log_scale>false</log_scale>
         <minimum>0.0</minimum>
-        <wuid>12e5a6d8:14c334c9085:-76f0</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7114</wuid>
         <show_hihi>true</show_hihi>
         <scale_format></scale_format>
         <show_scale>true</show_scale>
@@ -1832,7 +1832,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-76ef</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7113</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -1901,7 +1901,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-76ee</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7112</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -1937,7 +1937,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-76ed</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7111</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2014,7 +2014,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-76ec</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7110</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -2048,7 +2048,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-76eb</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-710f</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2092,7 +2092,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-76ea</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-710e</wuid>
       <scripts />
       <height>70</height>
       <name>Grouping Container</name>
@@ -2167,7 +2167,7 @@ $(pv_value)</tooltip>
         <horizontal>false</horizontal>
         <log_scale>false</log_scale>
         <minimum>0.0</minimum>
-        <wuid>12e5a6d8:14c334c9085:-76e9</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-710d</wuid>
         <show_hihi>true</show_hihi>
         <scale_format></scale_format>
         <show_scale>true</show_scale>
@@ -2217,7 +2217,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-76e8</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-710c</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2286,7 +2286,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-76e7</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-710b</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -2322,7 +2322,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-76e6</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-710a</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2399,7 +2399,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-76e5</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7109</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -2433,7 +2433,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-76e4</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-7108</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2475,7 +2475,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-76f9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-711d</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2553,7 +2553,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-76f8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-711c</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -2603,7 +2603,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-76f7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-711b</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2672,7 +2672,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-76f6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-711a</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -2708,7 +2708,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-76f5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7119</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2757,7 +2757,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-76f4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7118</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2826,7 +2826,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-76f3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-7117</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -2861,7 +2861,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7731</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7155</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>25</height>
@@ -2902,7 +2902,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7730</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7154</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2944,7 +2944,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-772f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7153</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -2988,7 +2988,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-772e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7152</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3037,7 +3037,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-772d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7151</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3106,7 +3106,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-772c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7150</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -3140,7 +3140,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-772b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-714f</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3183,7 +3183,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-772a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-714e</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3233,7 +3233,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7729</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-714d</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -3275,7 +3275,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7728</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-714c</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3318,7 +3318,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7727</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-714b</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3368,7 +3368,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7726</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-714a</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -3410,7 +3410,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7725</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7149</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3479,7 +3479,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7724</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7148</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -3515,7 +3515,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7723</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7147</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3564,7 +3564,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7722</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7146</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3633,7 +3633,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7721</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7145</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -3669,7 +3669,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7720</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7144</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3718,7 +3718,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-771f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7143</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3787,7 +3787,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-771e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7142</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -3823,7 +3823,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-771d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7141</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3900,7 +3900,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-771c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7140</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -3934,7 +3934,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-771b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-713f</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3975,7 +3975,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-771a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-713e</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -4044,7 +4044,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7719</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-713d</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -4078,7 +4078,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7715</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7139</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -4119,7 +4119,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7714</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-7138</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>14</height>

--- a/ADApp/op/opi/autoconvert/NDPlot.opi
+++ b/ADApp/op/opi/autoconvert/NDPlot.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-7691</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-70b5</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-768f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-70b3</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -269,7 +269,7 @@ $(pv_value)</tooltip>
       <color red="219" green="128" blue="4" />
     </trace_11_trace_color>
     <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-    <wuid>12e5a6d8:14c334c9085:-7690</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-70b4</wuid>
     <trace_2_buffer_size>100</trace_2_buffer_size>
     <trace_18_trace_color>
       <color red="255" green="0" blue="240" />
@@ -659,7 +659,7 @@ $(trace_0_y_pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-768e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-70b2</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>25</height>

--- a/ADApp/op/opi/autoconvert/NDPluginBase.opi
+++ b/ADApp/op/opi/autoconvert/NDPluginBase.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-75a4</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-6fc8</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-75a3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fc7</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -93,7 +93,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-757a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f9e</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -131,7 +131,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7579</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f9d</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -174,7 +174,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7578</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f9c</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -226,7 +226,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7577</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f9b</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -264,7 +264,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7576</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f9a</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -307,7 +307,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7575</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f99</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -359,7 +359,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7573</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f97</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -398,7 +398,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7572</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f96</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -450,7 +450,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7571</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f95</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -494,7 +494,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7570</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f94</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -532,7 +532,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-756f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f93</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -574,7 +574,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-756e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f92</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -618,7 +618,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-756d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f91</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -696,7 +696,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-75a2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fc6</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -732,7 +732,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-75a1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fc5</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -781,7 +781,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-75a0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fc4</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -822,7 +822,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-759f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fc3</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -891,7 +891,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-759e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fc2</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -927,7 +927,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-759d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fc1</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -976,7 +976,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-759c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fc0</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1045,7 +1045,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-759b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fbf</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -1081,7 +1081,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-759a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fbe</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1130,7 +1130,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7599</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fbd</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1172,7 +1172,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7598</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fbc</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -1216,7 +1216,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7597</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fbb</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1267,7 +1267,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7596</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fba</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1316,7 +1316,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7595</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fb9</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1359,7 +1359,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7594</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fb8</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1408,7 +1408,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7593</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fb7</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1449,7 +1449,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7592</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fb6</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1492,7 +1492,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7591</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fb5</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1569,7 +1569,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7590</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fb4</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -1605,7 +1605,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-758f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fb3</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1654,7 +1654,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-758e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fb2</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1723,7 +1723,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-758d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fb1</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -1759,7 +1759,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-758c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fb0</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1808,7 +1808,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-758b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6faf</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1849,7 +1849,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-758a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fae</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1892,7 +1892,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7589</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fad</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1943,7 +1943,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7588</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fac</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1992,7 +1992,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7587</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fab</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2035,7 +2035,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7586</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6faa</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2084,7 +2084,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7585</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fa9</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2127,7 +2127,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7584</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fa8</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2178,7 +2178,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7583</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fa7</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2227,7 +2227,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7582</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fa6</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2270,7 +2270,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7581</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fa5</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2319,7 +2319,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7580</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fa4</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2362,7 +2362,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-757f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fa3</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2411,7 +2411,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-757e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fa2</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2454,7 +2454,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-757d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fa1</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2503,7 +2503,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-757c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6fa0</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2572,7 +2572,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-757b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f9f</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -2608,7 +2608,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7574</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f98</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2657,7 +2657,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-756c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f90</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2699,7 +2699,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-756b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f8f</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -2743,7 +2743,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-756a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f8e</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />

--- a/ADApp/op/opi/autoconvert/NDProcess.opi
+++ b/ADApp/op/opi/autoconvert/NDProcess.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-752d</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-6f51</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-752c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f50</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -95,7 +95,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-752a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f4e</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -152,7 +152,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7509</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f2d</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -209,7 +209,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7507</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f2b</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -266,7 +266,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-7505</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f29</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -323,7 +323,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-74f4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f18</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -378,7 +378,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7529</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f4d</wuid>
     <scripts />
     <height>45</height>
     <name>Grouping Container</name>
@@ -420,7 +420,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7524</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f48</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -475,7 +475,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7528</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f4c</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -513,7 +513,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7527</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6f4b</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -555,7 +555,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>true</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-7526</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6f4a</wuid>
         <scripts />
         <height>18</height>
         <name>Menu Button</name>
@@ -599,7 +599,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7525</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6f49</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -649,7 +649,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7523</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f47</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -693,7 +693,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7522</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f46</wuid>
     <scripts />
     <height>120</height>
     <name>Grouping Container</name>
@@ -735,7 +735,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-7514</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f38</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -790,7 +790,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7521</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f45</wuid>
       <scripts />
       <height>95</height>
       <name>Grouping Container</name>
@@ -828,7 +828,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7520</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6f44</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -871,7 +871,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-751f</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6f43</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -920,7 +920,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-751e</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6f42</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -963,7 +963,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-751d</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6f41</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1012,7 +1012,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-751c</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6f40</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -1055,7 +1055,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-751b</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6f3f</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1106,7 +1106,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-751a</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6f3e</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1155,7 +1155,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-7519</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6f3d</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -1197,7 +1197,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>true</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-7518</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6f3c</wuid>
         <scripts />
         <height>19</height>
         <name>Menu Button</name>
@@ -1267,7 +1267,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7517</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6f3b</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -1302,7 +1302,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>true</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-7516</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6f3a</wuid>
         <scripts />
         <height>19</height>
         <name>Menu Button</name>
@@ -1372,7 +1372,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-7515</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6f39</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -1407,7 +1407,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7513</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f37</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1451,7 +1451,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7504</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f28</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -1491,7 +1491,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7503</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f27</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1540,7 +1540,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7502</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f26</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1582,7 +1582,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7501</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f25</wuid>
       <scripts />
       <height>19</height>
       <name>Menu Button</name>
@@ -1627,7 +1627,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7500</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f24</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -1667,7 +1667,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74ff</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f23</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1744,7 +1744,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74fe</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f22</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1778,7 +1778,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74fd</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f21</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1822,7 +1822,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-74fc</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f20</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -1860,7 +1860,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74fb</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f1f</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1903,7 +1903,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74fa</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f1e</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1955,7 +1955,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-74f7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f1b</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -1993,7 +1993,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74f6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f1a</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2034,7 +2034,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-74f5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f19</wuid>
       <scripts />
       <height>19</height>
       <style>1</style>
@@ -2090,7 +2090,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-74f2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f16</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -2131,7 +2131,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-74f1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f15</wuid>
     <scripts />
     <height>400</height>
     <name>Grouping Container</name>
@@ -2171,7 +2171,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-74bf</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ee3</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -2209,7 +2209,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-74be</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6ee2</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2278,7 +2278,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-74bd</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6ee1</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -2314,7 +2314,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-74bc</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6ee0</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2366,7 +2366,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-74bb</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6edf</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -2404,7 +2404,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-74ba</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6ede</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2473,7 +2473,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-74b9</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6edd</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -2509,7 +2509,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-74b8</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6edc</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2559,7 +2559,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74f0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f14</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>14</height>
@@ -2600,7 +2600,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74ef</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f13</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>14</height>
@@ -2641,7 +2641,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74ee</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f12</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>14</height>
@@ -2682,7 +2682,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74ed</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f11</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>14</height>
@@ -2723,7 +2723,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74ec</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f10</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>14</height>
@@ -2764,7 +2764,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74eb</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f0f</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>14</height>
@@ -2805,7 +2805,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74ea</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f0e</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>14</height>
@@ -2846,7 +2846,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74e9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f0d</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2915,7 +2915,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74e8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f0c</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -2951,7 +2951,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74e7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f0b</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3000,7 +3000,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74e6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f0a</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -3069,7 +3069,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74e5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f09</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -3105,7 +3105,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74e4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f08</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3154,7 +3154,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74e3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f07</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -3223,7 +3223,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74e2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f06</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -3259,7 +3259,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74e1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f05</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3308,7 +3308,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74e0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f04</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -3377,7 +3377,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74df</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f03</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -3413,7 +3413,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74de</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f02</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3462,7 +3462,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74dd</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f01</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -3531,7 +3531,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74dc</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6f00</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -3567,7 +3567,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74db</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6eff</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3616,7 +3616,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74da</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6efe</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -3685,7 +3685,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74d9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6efd</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -3721,7 +3721,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74d8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6efc</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3770,7 +3770,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74d7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6efb</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -3839,7 +3839,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74d6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6efa</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -3875,7 +3875,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74d5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ef9</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3924,7 +3924,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74d4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ef8</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -3993,7 +3993,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74d3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ef7</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -4029,7 +4029,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74d2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ef6</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4078,7 +4078,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74d1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ef5</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -4147,7 +4147,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74d0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ef4</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -4183,7 +4183,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74cf</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ef3</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4232,7 +4232,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74ce</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ef2</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -4301,7 +4301,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74cd</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ef1</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -4337,7 +4337,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74cc</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ef0</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4386,7 +4386,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74cb</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6eef</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -4455,7 +4455,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74ca</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6eee</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -4491,7 +4491,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74c9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6eed</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4540,7 +4540,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74c8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6eec</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -4609,7 +4609,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74c7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6eeb</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -4645,7 +4645,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74c6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6eea</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4694,7 +4694,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74c5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ee9</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -4763,7 +4763,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74c4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ee8</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -4799,7 +4799,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74c3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ee7</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4848,7 +4848,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74c2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ee6</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>14</height>
@@ -4889,7 +4889,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74c1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ee5</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>14</height>
@@ -4930,7 +4930,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74c0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ee4</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>14</height>
@@ -4974,7 +4974,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-74b3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ed7</wuid>
     <scripts />
     <height>73</height>
     <name>Grouping Container</name>
@@ -5016,7 +5016,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-74ac</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ed0</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -5069,7 +5069,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74b2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ed6</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -5112,7 +5112,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74b1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ed5</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -5161,7 +5161,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74b0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ed4</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -5204,7 +5204,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-74af</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ed3</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -5253,7 +5253,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-74ae</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ed2</wuid>
       <scripts />
       <height>19</height>
       <style>1</style>
@@ -5307,7 +5307,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-74ad</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ed1</wuid>
       <scripts />
       <height>19</height>
       <name>Menu Button</name>
@@ -5349,7 +5349,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-74ab</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ecf</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -5391,7 +5391,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-752b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f4f</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>25</height>
@@ -5432,7 +5432,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7512</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f36</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -5475,7 +5475,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7511</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f35</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5524,7 +5524,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7510</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f34</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -5567,7 +5567,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-750f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f33</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5616,7 +5616,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-750e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f32</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -5659,7 +5659,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-750d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f31</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5708,7 +5708,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-750c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f30</wuid>
     <scripts />
     <height>19</height>
     <style>1</style>
@@ -5762,7 +5762,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-750b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f2f</wuid>
     <scripts />
     <height>19</height>
     <name>Menu Button</name>
@@ -5832,7 +5832,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-750a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f2e</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -5866,7 +5866,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7508</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f2c</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -5907,7 +5907,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7506</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f2a</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -5948,7 +5948,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-74f9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f1d</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -5990,7 +5990,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-74f8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f1c</wuid>
     <scripts />
     <height>19</height>
     <name>Menu Button</name>
@@ -6032,7 +6032,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-74f3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6f17</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6073,7 +6073,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-74b7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6edb</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6115,7 +6115,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-74b6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6eda</wuid>
     <scripts />
     <height>19</height>
     <name>Menu Button</name>
@@ -6157,7 +6157,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-74b5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ed9</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6199,7 +6199,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-74b4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ed8</wuid>
     <scripts />
     <height>19</height>
     <name>Menu Button</name>
@@ -6241,7 +6241,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-74aa</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ece</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6284,7 +6284,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-74a9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ecd</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -6361,7 +6361,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-74a8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ecc</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -6395,7 +6395,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-74a7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ecb</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6464,7 +6464,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-74a6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6eca</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -6500,7 +6500,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-74a5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ec9</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -6549,7 +6549,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-74a4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ec8</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6591,7 +6591,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-74a3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ec7</wuid>
     <scripts />
     <height>19</height>
     <name>Menu Button</name>
@@ -6635,7 +6635,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-74a2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ec6</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -6684,7 +6684,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-74a1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ec5</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6725,7 +6725,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-74a0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ec4</wuid>
     <scripts />
     <height>19</height>
     <style>1</style>

--- a/ADApp/op/opi/autoconvert/NDROI.opi
+++ b/ADApp/op/opi/autoconvert/NDROI.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-73d5</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-6df9</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-73d4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6df8</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -95,7 +95,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-73d2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6df6</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -152,7 +152,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-73d0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6df4</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -209,7 +209,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-73cf</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6df3</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -264,7 +264,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-73cb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6def</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -302,7 +302,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-73ca</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dee</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -344,7 +344,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-73c9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ded</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -388,7 +388,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-73c8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dec</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -440,7 +440,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-73bf</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6de3</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -481,7 +481,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-73b7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ddb</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -519,7 +519,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-73b6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dda</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -562,7 +562,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-73b5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dd9</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -613,7 +613,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-73b4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dd8</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -664,7 +664,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-73b3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dd7</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -716,7 +716,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-73ab</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6dcf</wuid>
     <scripts />
     <height>40</height>
     <name>Grouping Container</name>
@@ -754,7 +754,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-73aa</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dce</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -823,7 +823,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-73a9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dcd</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -859,7 +859,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-73a8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dcc</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -936,7 +936,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-73a7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dcb</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -972,7 +972,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-73a6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dca</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1049,7 +1049,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-73a5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dc9</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1085,7 +1085,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-73a4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dc8</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1137,7 +1137,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-73a3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6dc7</wuid>
     <scripts />
     <height>63</height>
     <name>Grouping Container</name>
@@ -1175,7 +1175,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-73a2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dc6</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1244,7 +1244,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-73a1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dc5</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1280,7 +1280,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-73a0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dc4</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1357,7 +1357,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-739f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dc3</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1393,7 +1393,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-739e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dc2</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1444,7 +1444,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-739d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dc1</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1521,7 +1521,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-739c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dc0</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1592,7 +1592,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-739b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dbf</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -1679,7 +1679,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-739a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dbe</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -1766,7 +1766,7 @@ $(pv_value)</tooltip>
       <horizontal>false</horizontal>
       <log_scale>false</log_scale>
       <minimum>0.0</minimum>
-      <wuid>12e5a6d8:14c334c9085:-7399</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dbd</wuid>
       <show_hihi>true</show_hihi>
       <scale_format></scale_format>
       <show_scale>true</show_scale>
@@ -1819,7 +1819,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7398</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6dbc</wuid>
     <scripts />
     <height>65</height>
     <name>Grouping Container</name>
@@ -1859,7 +1859,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-7390</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6db4</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -1934,7 +1934,7 @@ $(pv_value)</tooltip>
         <horizontal>false</horizontal>
         <log_scale>false</log_scale>
         <minimum>0.0</minimum>
-        <wuid>12e5a6d8:14c334c9085:-738f</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6db3</wuid>
         <show_hihi>true</show_hihi>
         <scale_format></scale_format>
         <show_scale>true</show_scale>
@@ -2021,7 +2021,7 @@ $(pv_value)</tooltip>
         <horizontal>false</horizontal>
         <log_scale>false</log_scale>
         <minimum>0.0</minimum>
-        <wuid>12e5a6d8:14c334c9085:-738e</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6db2</wuid>
         <show_hihi>true</show_hihi>
         <scale_format></scale_format>
         <show_scale>true</show_scale>
@@ -2108,7 +2108,7 @@ $(pv_value)</tooltip>
         <horizontal>false</horizontal>
         <log_scale>false</log_scale>
         <minimum>0.0</minimum>
-        <wuid>12e5a6d8:14c334c9085:-738d</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6db1</wuid>
         <show_hihi>true</show_hihi>
         <scale_format></scale_format>
         <show_scale>true</show_scale>
@@ -2159,7 +2159,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7397</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dbb</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2228,7 +2228,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7396</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dba</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -2264,7 +2264,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7395</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6db9</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2341,7 +2341,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7394</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6db8</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -2377,7 +2377,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7393</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6db7</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2454,7 +2454,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7392</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6db6</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -2490,7 +2490,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7391</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6db5</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2542,7 +2542,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-738c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6db0</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -2580,7 +2580,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-738b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6daf</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2623,7 +2623,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-738a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dae</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2674,7 +2674,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7389</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dad</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2725,7 +2725,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7388</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6dac</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2777,7 +2777,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7387</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6dab</wuid>
     <scripts />
     <height>40</height>
     <name>Grouping Container</name>
@@ -2815,7 +2815,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7386</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6daa</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2858,7 +2858,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7385</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6da9</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2908,7 +2908,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7384</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6da8</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -2952,7 +2952,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7383</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6da7</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3002,7 +3002,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7382</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6da6</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -3045,7 +3045,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7381</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6da5</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -3089,7 +3089,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-7380</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6da4</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3139,7 +3139,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-73d3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6df7</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>25</height>
@@ -3180,7 +3180,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-73d1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6df5</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3221,7 +3221,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-73ce</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6df2</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3262,7 +3262,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-73cd</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6df1</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3303,7 +3303,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-73cc</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6df0</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3344,7 +3344,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-73c7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6deb</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3413,7 +3413,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-73c6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6dea</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -3447,7 +3447,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-73c5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6de9</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3489,7 +3489,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-73c4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6de8</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -3533,7 +3533,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-73c3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6de7</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3582,7 +3582,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-73c2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6de6</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3625,7 +3625,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-73c1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6de5</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3702,7 +3702,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-73c0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6de4</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -3736,7 +3736,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-73be</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6de2</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3779,7 +3779,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-73bd</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6de1</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3829,7 +3829,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-73bc</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6de0</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -3873,7 +3873,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-73bb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ddf</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3923,7 +3923,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-73ba</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6dde</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -3966,7 +3966,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-73b9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ddd</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -4010,7 +4010,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-73b8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ddc</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4059,7 +4059,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-73b2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6dd6</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -4102,7 +4102,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-73b1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6dd5</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4152,7 +4152,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-73b0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6dd4</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -4196,7 +4196,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-73af</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6dd3</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4246,7 +4246,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-73ae</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6dd2</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -4289,7 +4289,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-73ad</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6dd1</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -4333,7 +4333,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-73ac</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6dd0</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />

--- a/ADApp/op/opi/autoconvert/NDROI4.opi
+++ b/ADApp/op/opi/autoconvert/NDROI4.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-72ed</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-6d11</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-72ec</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d10</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -95,7 +95,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-72e4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d08</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -152,7 +152,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-72d9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cfd</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -209,7 +209,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-72cf</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cf3</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -266,7 +266,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-72c5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ce9</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -323,7 +323,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-72bb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cdf</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -380,7 +380,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-729b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cbf</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -437,7 +437,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-727c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ca0</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -492,7 +492,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-72ba</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cde</wuid>
     <scripts />
     <height>267</height>
     <name>Grouping Container</name>
@@ -534,7 +534,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color name="Gray_14" red="0" green="0" blue="0" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-72b4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cd8</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -587,7 +587,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-72b9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cdd</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -628,7 +628,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-72b8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cdc</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -669,7 +669,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-72b7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cdb</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -710,7 +710,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-72b6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cda</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -751,7 +751,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-72b5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cd9</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -793,7 +793,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-72b3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cd7</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -863,7 +863,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-72b2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cd6</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -898,7 +898,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-72b1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cd5</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -941,7 +941,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-72b0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cd4</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -995,7 +995,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-72af</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cd3</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1045,7 +1045,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-72ae</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cd2</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -1115,7 +1115,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-72ad</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cd1</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1150,7 +1150,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-72ac</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cd0</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -1193,7 +1193,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-72ab</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ccf</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1247,7 +1247,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-72aa</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cce</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1297,7 +1297,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-72a9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ccd</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -1367,7 +1367,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-72a8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ccc</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1402,7 +1402,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-72a7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ccb</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -1445,7 +1445,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-72a6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cca</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1499,7 +1499,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-72a5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cc9</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1549,7 +1549,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-72a4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cc8</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -1619,7 +1619,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-72a3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cc7</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1654,7 +1654,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-72a2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cc6</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -1697,7 +1697,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-72a1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cc5</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1751,7 +1751,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-72a0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6cc4</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1803,7 +1803,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7285</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ca9</wuid>
     <scripts />
     <height>189</height>
     <name>Grouping Container</name>
@@ -1842,7 +1842,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7284</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ca8</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -1885,7 +1885,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7283</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ca7</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -1928,7 +1928,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7282</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ca6</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -1971,7 +1971,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7281</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6ca5</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -2016,7 +2016,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-7267</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c8b</wuid>
     <scripts />
     <height>218</height>
     <name>Grouping Container</name>
@@ -2054,7 +2054,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-7266</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6c8a</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2096,7 +2096,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7265</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6c89</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -2139,7 +2139,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7264</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6c88</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -2182,7 +2182,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7263</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6c87</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -2225,7 +2225,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-7262</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6c86</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -2268,7 +2268,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-72eb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d0f</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>25</height>
@@ -2309,7 +2309,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-72ea</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d0e</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2350,7 +2350,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-72e9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d0d</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2391,7 +2391,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-72e8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d0c</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2432,7 +2432,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-72e7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d0b</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2473,7 +2473,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-72e6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d0a</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2514,7 +2514,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-72e5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d09</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2555,7 +2555,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-72e3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d07</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2597,7 +2597,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-72e2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d06</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -2641,7 +2641,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72e1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d05</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2690,7 +2690,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-72e0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d04</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2768,7 +2768,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-72df</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d03</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -2855,7 +2855,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-72de</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d02</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -2933,7 +2933,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72dd</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d01</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -2995,7 +2995,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72dc</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6d00</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -3057,7 +3057,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72db</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cff</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -3119,7 +3119,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72da</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cfe</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -3154,7 +3154,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-72d8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cfc</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -3198,7 +3198,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72d7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cfb</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3247,7 +3247,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-72d6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cfa</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3325,7 +3325,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-72d5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cf9</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -3412,7 +3412,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-72d4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cf8</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -3490,7 +3490,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72d3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cf7</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -3552,7 +3552,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72d2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cf6</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -3614,7 +3614,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72d1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cf5</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -3676,7 +3676,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72d0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cf4</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -3711,7 +3711,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-72ce</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cf2</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -3755,7 +3755,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72cd</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cf1</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3804,7 +3804,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-72cc</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cf0</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3882,7 +3882,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-72cb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cef</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -3969,7 +3969,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-72ca</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cee</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -4047,7 +4047,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72c9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ced</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -4109,7 +4109,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72c8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cec</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -4171,7 +4171,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72c7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ceb</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -4233,7 +4233,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72c6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cea</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -4268,7 +4268,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-72c4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ce8</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -4312,7 +4312,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72c3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ce7</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4361,7 +4361,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-72c2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ce6</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -4439,7 +4439,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-72c1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ce5</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -4526,7 +4526,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-72c0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ce4</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -4604,7 +4604,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72bf</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ce3</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -4666,7 +4666,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72be</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ce2</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -4728,7 +4728,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72bd</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ce1</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -4790,7 +4790,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-72bc</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ce0</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -4824,7 +4824,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-729f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cc3</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -4865,7 +4865,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-729e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cc2</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -4906,7 +4906,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-729d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cc1</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -4947,7 +4947,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-729c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cc0</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -5025,7 +5025,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-729a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cbe</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -5112,7 +5112,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-7299</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cbd</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -5190,7 +5190,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7298</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cbc</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -5252,7 +5252,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7297</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cbb</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -5314,7 +5314,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7296</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cba</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -5385,7 +5385,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-7295</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cb9</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -5472,7 +5472,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-7294</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cb8</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -5550,7 +5550,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7293</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cb7</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -5612,7 +5612,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7292</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cb6</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -5674,7 +5674,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7291</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cb5</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -5745,7 +5745,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-7290</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cb4</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -5832,7 +5832,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-728f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cb3</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -5910,7 +5910,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-728e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cb2</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -5972,7 +5972,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-728d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cb1</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -6034,7 +6034,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-728c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cb0</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -6105,7 +6105,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-728b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6caf</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -6192,7 +6192,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-728a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cae</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -6270,7 +6270,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7289</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cad</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -6332,7 +6332,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7288</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cac</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -6394,7 +6394,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7287</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6cab</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -6428,7 +6428,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7286</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6caa</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6469,7 +6469,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7280</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ca4</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6510,7 +6510,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-727f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ca3</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6551,7 +6551,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-727e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ca2</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6592,7 +6592,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-727d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6ca1</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6670,7 +6670,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-727b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c9f</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -6757,7 +6757,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-727a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c9e</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -6835,7 +6835,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7279</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c9d</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -6897,7 +6897,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7278</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c9c</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -6959,7 +6959,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7277</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c9b</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -7030,7 +7030,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-7276</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c9a</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -7117,7 +7117,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-7275</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c99</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -7195,7 +7195,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7274</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c98</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -7257,7 +7257,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7273</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c97</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -7319,7 +7319,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7272</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c96</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -7390,7 +7390,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-7271</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c95</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -7477,7 +7477,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-7270</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c94</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -7555,7 +7555,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-726f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c93</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -7617,7 +7617,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-726e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c92</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -7679,7 +7679,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-726d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c91</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -7750,7 +7750,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-726c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c90</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -7837,7 +7837,7 @@ $(pv_value)</tooltip>
     <horizontal>false</horizontal>
     <log_scale>false</log_scale>
     <minimum>0.0</minimum>
-    <wuid>12e5a6d8:14c334c9085:-726b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c8f</wuid>
     <show_hihi>true</show_hihi>
     <scale_format></scale_format>
     <show_scale>true</show_scale>
@@ -7915,7 +7915,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-726a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c8e</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -7977,7 +7977,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7269</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c8d</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -8039,7 +8039,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-7268</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c8c</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -8073,7 +8073,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-7261</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c85</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -8115,7 +8115,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-7260</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c84</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -8158,7 +8158,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-725f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c83</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -8201,7 +8201,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-725e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c82</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -8244,7 +8244,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-725d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6c81</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>

--- a/ADApp/op/opi/autoconvert/NDStats.opi
+++ b/ADApp/op/opi/autoconvert/NDStats.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-6ff8</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-6a1c</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6ff7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6a1b</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -95,7 +95,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6fdf</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6a03</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -152,7 +152,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6f77</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-699b</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -209,7 +209,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6f74</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6998</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -264,7 +264,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6ff5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6a19</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -305,7 +305,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6ff4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6a18</wuid>
     <scripts />
     <height>180</height>
     <name>Grouping Container</name>
@@ -347,7 +347,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-6ff3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a17</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -404,7 +404,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color name="Gray_14" red="0" green="0" blue="0" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-6fe7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a0b</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -459,7 +459,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6fe2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a06</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -498,7 +498,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>false</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-6fe1</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6a05</wuid>
         <scripts />
         <height>20</height>
         <name>Menu Button</name>
@@ -553,7 +553,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6fe0</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6a04</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -595,7 +595,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6ff2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a16</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -637,7 +637,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6ff1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a15</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -679,7 +679,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6ff0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a14</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -748,7 +748,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6fef</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a13</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -782,7 +782,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6fee</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a12</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -851,7 +851,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6fed</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a11</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -885,7 +885,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6fec</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a10</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -954,7 +954,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6feb</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a0f</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -988,7 +988,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6fea</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a0e</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1031,7 +1031,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6fe9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a0d</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1080,7 +1080,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6fe8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a0c</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1123,7 +1123,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6fe6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a0a</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1174,7 +1174,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6fe5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a09</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1225,7 +1225,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6fe4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a08</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1276,7 +1276,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6fe3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a07</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1328,7 +1328,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6fde</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6a02</wuid>
     <scripts />
     <height>21</height>
     <name>Grouping Container</name>
@@ -1370,7 +1370,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-6fdd</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a01</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -1423,7 +1423,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6fdc</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6a00</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1467,7 +1467,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6fd8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69fc</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -1505,7 +1505,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6fd7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69fb</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1574,7 +1574,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6fd6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69fa</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1610,7 +1610,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6fd5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69f9</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1662,7 +1662,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6fd4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69f8</wuid>
     <scripts />
     <height>200</height>
     <name>Grouping Container</name>
@@ -1704,7 +1704,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color name="Gray_14" red="0" green="0" blue="0" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-6fd3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69f7</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -1761,7 +1761,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-6fc0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69e4</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -1816,7 +1816,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6fd2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69f6</wuid>
       <scripts />
       <height>87</height>
       <name>Grouping Container</name>
@@ -1854,7 +1854,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6fd1</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69f5</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -1932,7 +1932,7 @@ $(pv_value)</tooltip>
         <horizontal>false</horizontal>
         <log_scale>false</log_scale>
         <minimum>0.0</minimum>
-        <wuid>12e5a6d8:14c334c9085:-6fd0</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69f4</wuid>
         <show_hihi>true</show_hihi>
         <scale_format></scale_format>
         <show_scale>true</show_scale>
@@ -2010,7 +2010,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6fcf</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69f3</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -2046,7 +2046,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6fce</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69f2</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2095,7 +2095,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6fcd</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69f1</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2173,7 +2173,7 @@ $(pv_value)</tooltip>
         <horizontal>false</horizontal>
         <log_scale>false</log_scale>
         <minimum>0.0</minimum>
-        <wuid>12e5a6d8:14c334c9085:-6fcc</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69f0</wuid>
         <show_hihi>true</show_hihi>
         <scale_format></scale_format>
         <show_scale>true</show_scale>
@@ -2251,7 +2251,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6fcb</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69ef</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -2287,7 +2287,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6fca</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69ee</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2339,7 +2339,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6fc9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69ed</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -2378,7 +2378,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>true</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-6fc8</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69ec</wuid>
         <scripts />
         <height>18</height>
         <name>Menu Button</name>
@@ -2422,7 +2422,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6fc7</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69eb</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2471,7 +2471,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6fc6</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69ea</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2515,7 +2515,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6fc5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69e9</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -2553,7 +2553,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6fc4</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69e8</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2596,7 +2596,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6fc3</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69e7</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2647,7 +2647,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6fc2</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69e6</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2696,7 +2696,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6fc1</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69e5</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2740,7 +2740,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6fbe</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69e2</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -2779,7 +2779,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>false</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-6fbd</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69e1</wuid>
         <scripts />
         <height>20</height>
         <name>Menu Button</name>
@@ -2918,7 +2918,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6fbc</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69e0</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2960,7 +2960,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6fbf</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69e3</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -3004,7 +3004,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6fbb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69df</wuid>
     <scripts />
     <height>130</height>
     <name>Grouping Container</name>
@@ -3046,7 +3046,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-6fba</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69de</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -3103,7 +3103,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color name="Gray_14" red="0" green="0" blue="0" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-6fb9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69dd</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -3158,7 +3158,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6fb7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69db</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -3196,7 +3196,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6fb6</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69da</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -3239,7 +3239,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6fb5</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69d9</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -3291,7 +3291,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6fb4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69d8</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -3330,7 +3330,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>true</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-6fb3</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69d7</wuid>
         <scripts />
         <height>18</height>
         <name>Menu Button</name>
@@ -3372,7 +3372,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
-        <wuid>12e5a6d8:14c334c9085:-6fb2</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69d6</wuid>
         <scripts />
         <height>20</height>
         <style>1</style>
@@ -3425,7 +3425,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6fb1</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69d5</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -3469,7 +3469,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6fb0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69d4</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -3507,7 +3507,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
-        <wuid>12e5a6d8:14c334c9085:-6faf</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69d3</wuid>
         <scripts />
         <height>20</height>
         <style>1</style>
@@ -3560,7 +3560,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
-        <wuid>12e5a6d8:14c334c9085:-6fae</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69d2</wuid>
         <scripts />
         <height>20</height>
         <style>1</style>
@@ -3613,7 +3613,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
-        <wuid>12e5a6d8:14c334c9085:-6fad</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69d1</wuid>
         <scripts />
         <height>20</height>
         <style>1</style>
@@ -3668,7 +3668,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6fac</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69d0</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -3720,7 +3720,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6fab</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69cf</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -3786,7 +3786,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6faa</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69ce</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -3820,7 +3820,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6fa9</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69cd</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -3862,7 +3862,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6fb8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69dc</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -3906,7 +3906,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6fa8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69cc</wuid>
     <scripts />
     <height>180</height>
     <name>Grouping Container</name>
@@ -3948,7 +3948,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color name="Gray_14" red="0" green="0" blue="0" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-6f98</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69bc</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -4003,7 +4003,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6f9e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69c2</wuid>
       <scripts />
       <height>21</height>
       <name>Grouping Container</name>
@@ -4045,7 +4045,7 @@ $(pv_value)</tooltip>
         <line_color>
           <color red="128" green="0" blue="255" />
         </line_color>
-        <wuid>12e5a6d8:14c334c9085:-6f9d</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69c1</wuid>
         <bg_gradient_color>
           <color red="255" green="255" blue="255" />
         </bg_gradient_color>
@@ -4098,7 +4098,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6f9c</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69c0</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -4142,7 +4142,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6f97</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69bb</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -4182,7 +4182,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6f96</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69ba</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -4231,7 +4231,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6f95</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-69b9</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -4273,7 +4273,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6fa7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69cb</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -4316,7 +4316,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6fa6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69ca</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4367,7 +4367,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6fa5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69c9</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4416,7 +4416,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6fa4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69c8</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -4459,7 +4459,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6fa3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69c7</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4508,7 +4508,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6fa2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69c6</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -4550,7 +4550,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6fa1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69c5</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -4594,7 +4594,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6fa0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69c4</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4643,7 +4643,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6f9f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69c3</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -4684,7 +4684,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6f9b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69bf</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -4753,7 +4753,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6f9a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69be</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -4789,7 +4789,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6f99</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69bd</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4840,7 +4840,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6f94</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69b8</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -4889,7 +4889,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6f93</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69b7</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -4931,7 +4931,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6f92</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69b6</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -5027,7 +5027,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6f91</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69b5</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -5071,7 +5071,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6f90</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69b4</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -5109,7 +5109,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6f8f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69b3</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -5152,7 +5152,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6f8e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69b2</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -5201,7 +5201,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6f8d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69b1</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -5244,7 +5244,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6f8c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69b0</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -5296,7 +5296,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6f83</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69a7</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -5334,7 +5334,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6f82</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69a6</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -5377,7 +5377,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6f81</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69a5</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -5426,7 +5426,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6f80</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69a4</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -5469,7 +5469,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6f7f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69a3</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -5521,7 +5521,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6f7e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69a2</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -5559,7 +5559,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6f7d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69a1</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -5602,7 +5602,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6f7c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-69a0</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -5651,7 +5651,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6f7b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-699f</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -5694,7 +5694,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6f7a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-699e</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -5744,7 +5744,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6ff6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6a1a</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>25</height>
@@ -5786,7 +5786,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6fdb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69ff</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -5830,7 +5830,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6fda</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69fe</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5879,7 +5879,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6fd9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69fd</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -5920,7 +5920,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6f8b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69af</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -5963,7 +5963,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6f8a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69ae</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -6012,7 +6012,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6f89</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69ad</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6055,7 +6055,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6f88</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69ac</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -6104,7 +6104,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6f87</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69ab</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6147,7 +6147,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6f86</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69aa</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -6196,7 +6196,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6f85</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69a9</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6239,7 +6239,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6f84</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-69a8</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -6289,7 +6289,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6f79</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-699d</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -6430,7 +6430,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6f78</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-699c</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6471,7 +6471,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6f76</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-699a</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6512,7 +6512,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6f75</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6999</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6554,7 +6554,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6f73</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6997</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -6615,7 +6615,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6f72</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6996</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -6656,7 +6656,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6f71</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6995</wuid>
     <scripts />
     <height>20</height>
     <style>1</style>

--- a/ADApp/op/opi/autoconvert/NDStats5.opi
+++ b/ADApp/op/opi/autoconvert/NDStats5.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-6eac</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-68d0</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6eab</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68cf</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -95,7 +95,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6ea7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68cb</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -152,7 +152,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6ea0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68c4</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -209,7 +209,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6e97</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68bb</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -266,7 +266,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6e85</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68a9</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -323,7 +323,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6e73</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6897</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -380,7 +380,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6e61</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6885</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -437,7 +437,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6e4f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6873</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -492,7 +492,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6e3b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-685f</wuid>
     <scripts />
     <height>275</height>
     <name>Grouping Container</name>
@@ -530,7 +530,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6e3a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-685e</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -573,7 +573,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6e39</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-685d</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -624,7 +624,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6e38</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-685c</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -675,7 +675,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6e37</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-685b</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -726,7 +726,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6e36</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-685a</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -777,7 +777,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6e35</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6859</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -827,7 +827,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6eaa</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68ce</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>25</height>
@@ -868,7 +868,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6ea9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68cd</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -909,7 +909,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6ea8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68cc</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -950,7 +950,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6ea6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68ca</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -991,7 +991,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6ea5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68c9</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1032,7 +1032,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6ea4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68c8</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1073,7 +1073,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6ea3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68c7</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1114,7 +1114,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6ea2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68c6</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1155,7 +1155,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6ea1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68c5</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1196,7 +1196,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6e9f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68c3</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1237,7 +1237,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6e9e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68c2</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1278,7 +1278,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6e9d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68c1</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1319,7 +1319,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6e9c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68c0</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1360,7 +1360,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6e9b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68bf</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1401,7 +1401,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6e9a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68be</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1442,7 +1442,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6e99</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68bd</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1483,7 +1483,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6e98</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68bc</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1524,7 +1524,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6e96</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68ba</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -1566,7 +1566,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e95</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68b9</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -1610,7 +1610,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e94</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68b8</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1687,7 +1687,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e93</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68b7</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -1723,7 +1723,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e92</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68b6</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1774,7 +1774,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e91</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68b5</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1825,7 +1825,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e90</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68b4</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1875,7 +1875,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e8f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68b3</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -1919,7 +1919,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e8e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68b2</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -1969,7 +1969,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e8d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68b1</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -2013,7 +2013,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e8c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68b0</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2064,7 +2064,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e8b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68af</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2115,7 +2115,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e8a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68ae</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2166,7 +2166,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e89</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68ad</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2217,7 +2217,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e88</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68ac</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2268,7 +2268,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e87</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68ab</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2319,7 +2319,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e86</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68aa</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2368,7 +2368,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6e84</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68a8</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2410,7 +2410,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e83</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68a7</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -2454,7 +2454,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e82</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68a6</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2531,7 +2531,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e81</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68a5</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -2567,7 +2567,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e80</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68a4</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2618,7 +2618,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e7f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68a3</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2669,7 +2669,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e7e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68a2</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2719,7 +2719,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e7d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68a1</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -2763,7 +2763,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e7c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-68a0</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2813,7 +2813,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e7b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-689f</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -2857,7 +2857,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e7a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-689e</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2908,7 +2908,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e79</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-689d</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -2959,7 +2959,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e78</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-689c</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3010,7 +3010,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e77</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-689b</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3061,7 +3061,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e76</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-689a</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3112,7 +3112,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e75</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6899</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3163,7 +3163,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e74</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6898</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3212,7 +3212,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6e72</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6896</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3254,7 +3254,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e71</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6895</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -3298,7 +3298,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e70</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6894</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3375,7 +3375,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e6f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6893</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -3411,7 +3411,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e6e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6892</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3462,7 +3462,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e6d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6891</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3513,7 +3513,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e6c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6890</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3563,7 +3563,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e6b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-688f</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -3607,7 +3607,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e6a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-688e</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3657,7 +3657,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e69</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-688d</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -3701,7 +3701,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e68</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-688c</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3752,7 +3752,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e67</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-688b</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3803,7 +3803,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e66</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-688a</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3854,7 +3854,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e65</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6889</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3905,7 +3905,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e64</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6888</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3956,7 +3956,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e63</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6887</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4007,7 +4007,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e62</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6886</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4056,7 +4056,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6e60</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6884</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -4098,7 +4098,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e5f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6883</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -4142,7 +4142,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e5e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6882</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4219,7 +4219,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e5d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6881</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -4255,7 +4255,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e5c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6880</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4306,7 +4306,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e5b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-687f</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4357,7 +4357,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e5a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-687e</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4407,7 +4407,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e59</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-687d</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -4451,7 +4451,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e58</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-687c</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4501,7 +4501,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e57</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-687b</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -4545,7 +4545,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e56</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-687a</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4596,7 +4596,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e55</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6879</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4647,7 +4647,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e54</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6878</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4698,7 +4698,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e53</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6877</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4749,7 +4749,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e52</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6876</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4800,7 +4800,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e51</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6875</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4851,7 +4851,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e50</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6874</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4900,7 +4900,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6e4e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6872</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -4942,7 +4942,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e4d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6871</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -4986,7 +4986,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e4c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6870</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5063,7 +5063,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e4b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-686f</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -5099,7 +5099,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e4a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-686e</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5150,7 +5150,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e49</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-686d</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5201,7 +5201,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e48</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-686c</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5251,7 +5251,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e47</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-686b</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -5295,7 +5295,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e46</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-686a</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5345,7 +5345,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e45</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6869</wuid>
     <scripts />
     <height>18</height>
     <name>Menu Button</name>
@@ -5389,7 +5389,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e44</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6868</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5440,7 +5440,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e43</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6867</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5491,7 +5491,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e42</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6866</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5542,7 +5542,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e41</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6865</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5593,7 +5593,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e40</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6864</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5644,7 +5644,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e3f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6863</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5695,7 +5695,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e3e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6862</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5744,7 +5744,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6e3d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6861</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -5786,7 +5786,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e3c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6860</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -5867,7 +5867,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6e34</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6858</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -5910,7 +5910,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e33</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6857</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5961,7 +5961,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e32</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6856</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -6012,7 +6012,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e31</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6855</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -6063,7 +6063,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e30</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6854</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -6114,7 +6114,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6e2f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6853</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -6164,7 +6164,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e2e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6852</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -6246,7 +6246,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e2d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6851</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -6328,7 +6328,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e2c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6850</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -6410,7 +6410,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6e2b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-684f</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>

--- a/ADApp/op/opi/autoconvert/NDStdArrays.opi
+++ b/ADApp/op/opi/autoconvert/NDStdArrays.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-6da7</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-67cb</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6da6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-67ca</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -93,7 +93,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6da4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-67c8</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -132,7 +132,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6da5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-67c9</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>25</height>

--- a/ADApp/op/opi/autoconvert/NDTimeSeries.opi
+++ b/ADApp/op/opi/autoconvert/NDTimeSeries.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-6d63</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-6787</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -36,7 +36,7 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6d61</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6785</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -74,7 +74,7 @@
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6d60</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6784</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -117,7 +117,7 @@
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6d5f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6783</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -169,7 +169,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6d5e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6782</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -208,7 +208,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6d5d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6781</wuid>
       <scripts />
       <height>18</height>
       <name>Menu Button</name>
@@ -250,7 +250,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6d5c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6780</wuid>
       <scripts />
       <height>20</height>
       <style>1</style>
@@ -303,7 +303,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6d5b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-677f</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -347,7 +347,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6d5a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-677e</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -385,7 +385,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6d59</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-677d</wuid>
       <scripts />
       <height>20</height>
       <style>1</style>
@@ -438,7 +438,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6d58</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-677c</wuid>
       <scripts />
       <height>20</height>
       <style>1</style>
@@ -491,7 +491,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6d57</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-677b</wuid>
       <scripts />
       <height>20</height>
       <style>1</style>
@@ -546,7 +546,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6d56</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-677a</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -598,7 +598,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6d55</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6779</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -664,7 +664,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6d54</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6778</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -698,7 +698,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6d53</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6777</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -742,7 +742,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6d52</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6776</wuid>
     <scripts />
     <height>25</height>
     <name>Grouping Container</name>
@@ -784,7 +784,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-6d51</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6775</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -837,7 +837,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6d50</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6774</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>25</height>
@@ -1057,7 +1057,7 @@ $(pv_value)</tooltip>
       <color red="219" green="128" blue="4" />
     </trace_11_trace_color>
     <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-    <wuid>12e5a6d8:14c334c9085:-6d62</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6786</wuid>
     <trace_2_buffer_size>100</trace_2_buffer_size>
     <trace_18_trace_color>
       <color red="255" green="0" blue="240" />

--- a/ADApp/op/opi/autoconvert/NDTimeSeriesAll.opi
+++ b/ADApp/op/opi/autoconvert/NDTimeSeriesAll.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-6d3a</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-675e</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6d39</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-675d</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -93,7 +93,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6d37</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-675b</wuid>
     <scripts />
     <height>200</height>
     <name>Grouping Container</name>
@@ -309,7 +309,7 @@ $(pv_value)</tooltip>
         <color red="219" green="128" blue="4" />
       </trace_11_trace_color>
       <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-      <wuid>12e5a6d8:14c334c9085:-6d36</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-675a</wuid>
       <trace_2_buffer_size>100</trace_2_buffer_size>
       <trace_18_trace_color>
         <color red="255" green="0" blue="240" />
@@ -877,7 +877,7 @@ $(trace_0_y_pv_value)</tooltip>
         <color red="219" green="128" blue="4" />
       </trace_11_trace_color>
       <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-      <wuid>12e5a6d8:14c334c9085:-6d35</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6759</wuid>
       <trace_2_buffer_size>100</trace_2_buffer_size>
       <trace_18_trace_color>
         <color red="255" green="0" blue="240" />
@@ -1445,7 +1445,7 @@ $(trace_0_y_pv_value)</tooltip>
         <color red="219" green="128" blue="4" />
       </trace_11_trace_color>
       <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-      <wuid>12e5a6d8:14c334c9085:-6d34</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6758</wuid>
       <trace_2_buffer_size>100</trace_2_buffer_size>
       <trace_18_trace_color>
         <color red="255" green="0" blue="240" />
@@ -2013,7 +2013,7 @@ $(trace_0_y_pv_value)</tooltip>
         <color red="219" green="128" blue="4" />
       </trace_11_trace_color>
       <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-      <wuid>12e5a6d8:14c334c9085:-6d33</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6757</wuid>
       <trace_2_buffer_size>100</trace_2_buffer_size>
       <trace_18_trace_color>
         <color red="255" green="0" blue="240" />
@@ -2406,7 +2406,7 @@ $(trace_0_y_pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6d32</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6756</wuid>
     <scripts />
     <height>405</height>
     <name>Grouping Container</name>
@@ -2446,7 +2446,7 @@ $(trace_0_y_pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6d2d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6751</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -2484,7 +2484,7 @@ $(trace_0_y_pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
-        <wuid>12e5a6d8:14c334c9085:-6d2c</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6750</wuid>
         <scripts />
         <height>20</height>
         <style>1</style>
@@ -2537,7 +2537,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
-        <wuid>12e5a6d8:14c334c9085:-6d2b</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-674f</wuid>
         <scripts />
         <height>20</height>
         <style>1</style>
@@ -2590,7 +2590,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
-        <wuid>12e5a6d8:14c334c9085:-6d2a</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-674e</wuid>
         <scripts />
         <height>20</height>
         <style>1</style>
@@ -2645,7 +2645,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6d29</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-674d</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2697,7 +2697,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6d28</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-674c</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -2763,7 +2763,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6d27</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-674b</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -2797,7 +2797,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6d26</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-674a</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2841,7 +2841,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6d25</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6749</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -2879,7 +2879,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6d24</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6748</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -2922,7 +2922,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6d23</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6747</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -2974,7 +2974,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6d22</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6746</wuid>
       <scripts />
       <height>20</height>
       <name>Grouping Container</name>
@@ -3013,7 +3013,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>true</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-6d21</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6745</wuid>
         <scripts />
         <height>18</height>
         <name>Menu Button</name>
@@ -3055,7 +3055,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
-        <wuid>12e5a6d8:14c334c9085:-6d20</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6744</wuid>
         <scripts />
         <height>20</height>
         <style>1</style>
@@ -3108,7 +3108,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6d1f</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6743</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -3152,7 +3152,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6d1e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6742</wuid>
       <scripts />
       <height>200</height>
       <name>Grouping Container</name>
@@ -3368,7 +3368,7 @@ $(pv_value)</tooltip>
           <color red="219" green="128" blue="4" />
         </trace_11_trace_color>
         <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-        <wuid>12e5a6d8:14c334c9085:-6d1d</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6741</wuid>
         <trace_2_buffer_size>100</trace_2_buffer_size>
         <trace_18_trace_color>
           <color red="255" green="0" blue="240" />
@@ -3936,7 +3936,7 @@ $(trace_0_y_pv_value)</tooltip>
           <color red="219" green="128" blue="4" />
         </trace_11_trace_color>
         <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-        <wuid>12e5a6d8:14c334c9085:-6d1c</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6740</wuid>
         <trace_2_buffer_size>100</trace_2_buffer_size>
         <trace_18_trace_color>
           <color red="255" green="0" blue="240" />
@@ -4504,7 +4504,7 @@ $(trace_0_y_pv_value)</tooltip>
           <color red="219" green="128" blue="4" />
         </trace_11_trace_color>
         <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-        <wuid>12e5a6d8:14c334c9085:-6d1b</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-673f</wuid>
         <trace_2_buffer_size>100</trace_2_buffer_size>
         <trace_18_trace_color>
           <color red="255" green="0" blue="240" />
@@ -5073,7 +5073,7 @@ $(trace_0_y_pv_value)</tooltip>
         <color red="219" green="128" blue="4" />
       </trace_11_trace_color>
       <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-      <wuid>12e5a6d8:14c334c9085:-6d31</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6755</wuid>
       <trace_2_buffer_size>100</trace_2_buffer_size>
       <trace_18_trace_color>
         <color red="255" green="0" blue="240" />
@@ -5641,7 +5641,7 @@ $(trace_0_y_pv_value)</tooltip>
         <color red="219" green="128" blue="4" />
       </trace_11_trace_color>
       <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-      <wuid>12e5a6d8:14c334c9085:-6d30</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6754</wuid>
       <trace_2_buffer_size>100</trace_2_buffer_size>
       <trace_18_trace_color>
         <color red="255" green="0" blue="240" />
@@ -6209,7 +6209,7 @@ $(trace_0_y_pv_value)</tooltip>
         <color red="219" green="128" blue="4" />
       </trace_11_trace_color>
       <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-      <wuid>12e5a6d8:14c334c9085:-6d2f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6753</wuid>
       <trace_2_buffer_size>100</trace_2_buffer_size>
       <trace_18_trace_color>
         <color red="255" green="0" blue="240" />
@@ -6777,7 +6777,7 @@ $(trace_0_y_pv_value)</tooltip>
         <color red="219" green="128" blue="4" />
       </trace_11_trace_color>
       <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-      <wuid>12e5a6d8:14c334c9085:-6d2e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6752</wuid>
       <trace_2_buffer_size>100</trace_2_buffer_size>
       <trace_18_trace_color>
         <color red="255" green="0" blue="240" />
@@ -7168,7 +7168,7 @@ $(trace_0_y_pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6d38</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-675c</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>25</height>
@@ -7387,7 +7387,7 @@ $(trace_0_y_pv_value)</tooltip>
       <color red="219" green="128" blue="4" />
     </trace_11_trace_color>
     <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-    <wuid>12e5a6d8:14c334c9085:-6d1a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-673e</wuid>
     <trace_2_buffer_size>100</trace_2_buffer_size>
     <trace_18_trace_color>
       <color red="255" green="0" blue="240" />
@@ -7955,7 +7955,7 @@ $(trace_0_y_pv_value)</tooltip>
       <color red="219" green="128" blue="4" />
     </trace_11_trace_color>
     <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-    <wuid>12e5a6d8:14c334c9085:-6d19</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-673d</wuid>
     <trace_2_buffer_size>100</trace_2_buffer_size>
     <trace_18_trace_color>
       <color red="255" green="0" blue="240" />
@@ -8523,7 +8523,7 @@ $(trace_0_y_pv_value)</tooltip>
       <color red="219" green="128" blue="4" />
     </trace_11_trace_color>
     <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-    <wuid>12e5a6d8:14c334c9085:-6d18</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-673c</wuid>
     <trace_2_buffer_size>100</trace_2_buffer_size>
     <trace_18_trace_color>
       <color red="255" green="0" blue="240" />
@@ -9091,7 +9091,7 @@ $(trace_0_y_pv_value)</tooltip>
       <color red="219" green="128" blue="4" />
     </trace_11_trace_color>
     <trace_14_name>$(trace_14_y_pv)</trace_14_name>
-    <wuid>12e5a6d8:14c334c9085:-6d17</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-673b</wuid>
     <trace_2_buffer_size>100</trace_2_buffer_size>
     <trace_18_trace_color>
       <color red="255" green="0" blue="240" />

--- a/ADApp/op/opi/autoconvert/NDTransform.opi
+++ b/ADApp/op/opi/autoconvert/NDTransform.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-6cf1</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-6715</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6cf0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6714</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -93,7 +93,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6cee</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6712</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -134,7 +134,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6ced</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6711</wuid>
     <scripts />
     <height>135</height>
     <name>Grouping Container</name>
@@ -176,7 +176,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color name="Gray_13" red="45" green="45" blue="45" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-6cec</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6710</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -231,7 +231,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6ce9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-670d</wuid>
       <scripts />
       <height>19</height>
       <name>Grouping Container</name>
@@ -272,7 +272,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6ce8</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-670c</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -327,7 +327,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6ce7</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-670b</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -382,7 +382,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6ce6</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-670a</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -437,7 +437,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6ce5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6709</wuid>
       <scripts />
       <height>13</height>
       <name>Grouping Container</name>
@@ -478,7 +478,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6ce4</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6708</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -533,7 +533,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6ce3</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6707</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -588,7 +588,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6ce2</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6706</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -643,7 +643,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6ce1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6705</wuid>
       <scripts />
       <height>19</height>
       <name>Grouping Container</name>
@@ -684,7 +684,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6ce0</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6704</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -739,7 +739,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6cdf</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6703</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -794,7 +794,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6cde</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6702</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -849,7 +849,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6cdd</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6701</wuid>
       <scripts />
       <height>13</height>
       <name>Grouping Container</name>
@@ -890,7 +890,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6cdc</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6700</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -945,7 +945,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6cdb</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-66ff</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -1000,7 +1000,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6cda</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-66fe</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -1055,7 +1055,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6cd1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-66f5</wuid>
       <scripts />
       <height>19</height>
       <name>Grouping Container</name>
@@ -1096,7 +1096,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6cd0</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-66f4</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -1151,7 +1151,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6ccf</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-66f3</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -1206,7 +1206,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6cce</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-66f2</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -1261,7 +1261,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6ccd</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-66f1</wuid>
       <scripts />
       <height>13</height>
       <name>Grouping Container</name>
@@ -1302,7 +1302,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6ccc</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-66f0</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -1357,7 +1357,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6ccb</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-66ef</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -1412,7 +1412,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6cca</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-66ee</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -1467,7 +1467,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6cc9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-66ed</wuid>
       <scripts />
       <height>19</height>
       <name>Grouping Container</name>
@@ -1508,7 +1508,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6cc8</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-66ec</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -1563,7 +1563,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6cc7</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-66eb</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -1618,7 +1618,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6cc6</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-66ea</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -1673,7 +1673,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6cc5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-66e9</wuid>
       <scripts />
       <height>13</height>
       <name>Grouping Container</name>
@@ -1714,7 +1714,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6cc4</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-66e8</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -1769,7 +1769,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6cc3</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-66e7</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -1824,7 +1824,7 @@ $(pv_value)</tooltip>
         <arrow_length>20</arrow_length>
         <visible>true</visible>
         <fill_level>100.0</fill_level>
-        <wuid>12e5a6d8:14c334c9085:-6cc2</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-66e6</wuid>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
         <arrows>0</arrows>
@@ -1877,7 +1877,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6ceb</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-670f</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -1919,7 +1919,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6cea</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-670e</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1961,7 +1961,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6cd9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-66fd</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2002,7 +2002,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6cd8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-66fc</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2043,7 +2043,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6cd7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-66fb</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2084,7 +2084,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6cd6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-66fa</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2125,7 +2125,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6cd5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-66f9</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2166,7 +2166,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6cd4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-66f8</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2207,7 +2207,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6cd3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-66f7</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2248,7 +2248,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6cd2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-66f6</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2290,7 +2290,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6cef</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6713</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>25</height>

--- a/ADApp/op/opi/autoconvert/commonPlugins.opi
+++ b/ADApp/op/opi/autoconvert/commonPlugins.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-6c55</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-6679</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color red="128" green="0" blue="255" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6c54</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6678</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -93,7 +93,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6baa</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65ce</wuid>
     <scripts />
     <height>145</height>
     <name>Grouping Container</name>
@@ -133,7 +133,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6ba9</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65cd</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -184,7 +184,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6ba8</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65cc</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -235,7 +235,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6ba7</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65cb</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -286,7 +286,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6ba6</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65ca</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -337,7 +337,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6ba5</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65c9</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -388,7 +388,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6ba4</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65c8</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -439,7 +439,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6ba3</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65c7</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -490,7 +490,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6ba2</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65c6</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -541,7 +541,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6ba1</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65c5</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -592,7 +592,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6ba0</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65c4</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -643,7 +643,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b9f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65c3</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -694,7 +694,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b9e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65c2</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -771,7 +771,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b9d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65c1</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -806,7 +806,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b9c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65c0</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -850,7 +850,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b9b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65bf</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -900,7 +900,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b9a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65be</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -970,7 +970,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b99</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65bd</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1005,7 +1005,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b98</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65bc</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1049,7 +1049,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b97</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65bb</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1099,7 +1099,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b96</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65ba</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1169,7 +1169,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b95</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65b9</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1204,7 +1204,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b94</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65b8</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1248,7 +1248,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b93</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65b7</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1298,7 +1298,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b92</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65b6</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1368,7 +1368,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b91</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65b5</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1403,7 +1403,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b90</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65b4</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1447,7 +1447,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b8f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65b3</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1497,7 +1497,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b8e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65b2</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1567,7 +1567,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b8d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65b1</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1602,7 +1602,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b8c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65b0</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1646,7 +1646,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b8b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65af</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1696,7 +1696,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b8a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65ae</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1766,7 +1766,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b89</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65ad</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -1801,7 +1801,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b88</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65ac</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1845,7 +1845,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b87</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65ab</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1895,7 +1895,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b86</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65aa</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1938,7 +1938,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b85</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65a9</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -1992,7 +1992,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b84</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65a8</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2042,7 +2042,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b83</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65a7</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -2096,7 +2096,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b82</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65a6</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2146,7 +2146,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b81</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65a5</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -2200,7 +2200,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b80</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65a4</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2250,7 +2250,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b7f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65a3</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -2304,7 +2304,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b7e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65a2</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2354,7 +2354,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b7d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65a1</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -2408,7 +2408,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b7c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-65a0</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2458,7 +2458,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b7b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-659f</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -2512,7 +2512,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b7a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-659e</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2563,7 +2563,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b79</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-659d</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2614,7 +2614,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b78</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-659c</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2665,7 +2665,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b77</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-659b</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2716,7 +2716,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b76</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-659a</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2767,7 +2767,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b75</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6599</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2818,7 +2818,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b74</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6598</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2869,7 +2869,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b73</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6597</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2920,7 +2920,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b72</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6596</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2971,7 +2971,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b71</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6595</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3022,7 +3022,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b70</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6594</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3073,7 +3073,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b6f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6593</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3124,7 +3124,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b6e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6592</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3176,7 +3176,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6b6d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6591</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -3216,7 +3216,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b6c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6590</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3267,7 +3267,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b6b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-658f</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3344,7 +3344,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b6a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-658e</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -3379,7 +3379,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b69</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-658d</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -3423,7 +3423,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b68</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-658c</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3473,7 +3473,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b67</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-658b</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -3516,7 +3516,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>false</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6b66</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-658a</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -3570,7 +3570,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b65</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6589</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3621,7 +3621,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b64</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6588</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3672,7 +3672,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6b63</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6587</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -3722,7 +3722,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6c53</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6677</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>25</height>
@@ -3763,7 +3763,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6c52</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6676</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3804,7 +3804,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6c51</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6675</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3847,7 +3847,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c50</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6674</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3898,7 +3898,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c4f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6673</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -3949,7 +3949,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c4e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6672</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4000,7 +4000,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c4d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6671</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4051,7 +4051,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c4c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6670</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4102,7 +4102,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c4b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-666f</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4153,7 +4153,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c4a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-666e</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4204,7 +4204,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c49</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-666d</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4255,7 +4255,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c48</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-666c</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4306,7 +4306,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c47</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-666b</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4357,7 +4357,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c46</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-666a</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4408,7 +4408,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c45</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6669</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4459,7 +4459,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c44</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6668</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4510,7 +4510,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c43</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6667</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4561,7 +4561,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c42</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6666</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4612,7 +4612,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c41</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6665</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4663,7 +4663,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c40</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6664</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4714,7 +4714,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c3f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6663</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4765,7 +4765,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c3e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6662</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4816,7 +4816,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c3d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6661</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4867,7 +4867,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c3c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6660</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4918,7 +4918,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c3b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-665f</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -4969,7 +4969,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c3a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-665e</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5020,7 +5020,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c39</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-665d</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5071,7 +5071,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c38</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-665c</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5122,7 +5122,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c37</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-665b</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5173,7 +5173,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c36</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-665a</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5224,7 +5224,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c35</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6659</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5273,7 +5273,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6c34</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6658</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -5314,7 +5314,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6c33</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6657</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -5355,7 +5355,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6c32</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6656</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -5424,7 +5424,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c31</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6655</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -5459,7 +5459,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c30</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6654</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -5503,7 +5503,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c2f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6653</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5553,7 +5553,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c2e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6652</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -5623,7 +5623,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c2d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6651</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -5658,7 +5658,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c2c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6650</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -5702,7 +5702,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c2b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-664f</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5752,7 +5752,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c2a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-664e</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -5822,7 +5822,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c29</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-664d</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -5857,7 +5857,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c28</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-664c</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -5901,7 +5901,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c27</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-664b</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -5951,7 +5951,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c26</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-664a</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -6021,7 +6021,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c25</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6649</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -6056,7 +6056,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c24</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6648</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -6100,7 +6100,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c23</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6647</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -6150,7 +6150,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c22</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6646</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -6220,7 +6220,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c21</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6645</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -6255,7 +6255,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c20</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6644</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -6299,7 +6299,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c1f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6643</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -6349,7 +6349,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c1e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6642</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -6419,7 +6419,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c1d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6641</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -6454,7 +6454,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c1c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6640</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -6498,7 +6498,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c1b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-663f</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -6548,7 +6548,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c1a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-663e</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -6618,7 +6618,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c19</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-663d</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -6653,7 +6653,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c18</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-663c</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -6697,7 +6697,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c17</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-663b</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -6747,7 +6747,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c16</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-663a</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -6817,7 +6817,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c15</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6639</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -6852,7 +6852,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c14</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6638</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -6896,7 +6896,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c13</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6637</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -6946,7 +6946,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c12</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6636</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -7016,7 +7016,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c11</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6635</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -7051,7 +7051,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c10</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6634</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -7095,7 +7095,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c0f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6633</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -7145,7 +7145,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c0e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6632</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -7215,7 +7215,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c0d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6631</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -7250,7 +7250,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c0c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6630</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -7294,7 +7294,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c0b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-662f</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -7344,7 +7344,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c0a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-662e</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -7414,7 +7414,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c09</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-662d</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -7449,7 +7449,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c08</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-662c</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -7493,7 +7493,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c07</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-662b</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -7543,7 +7543,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c06</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-662a</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -7613,7 +7613,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c05</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6629</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -7648,7 +7648,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c04</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6628</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -7692,7 +7692,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c03</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6627</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -7742,7 +7742,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c02</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6626</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -7812,7 +7812,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6c01</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6625</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -7847,7 +7847,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6c00</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6624</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -7891,7 +7891,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bff</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6623</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -7941,7 +7941,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bfe</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6622</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -8011,7 +8011,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bfd</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6621</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -8046,7 +8046,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bfc</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6620</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -8090,7 +8090,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bfb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-661f</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -8140,7 +8140,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bfa</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-661e</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -8182,7 +8182,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6bf9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-661d</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -8224,7 +8224,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bf8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-661c</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -8278,7 +8278,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bf7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-661b</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -8328,7 +8328,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bf6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-661a</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -8382,7 +8382,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bf5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6619</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -8432,7 +8432,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bf4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6618</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -8486,7 +8486,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bf3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6617</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -8536,7 +8536,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bf2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6616</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -8590,7 +8590,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bf1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6615</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -8640,7 +8640,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bf0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6614</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -8694,7 +8694,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bef</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6613</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -8744,7 +8744,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bee</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6612</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -8798,7 +8798,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bed</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6611</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -8848,7 +8848,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bec</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6610</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -8902,7 +8902,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6beb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-660f</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -8952,7 +8952,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bea</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-660e</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -9006,7 +9006,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6be9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-660d</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -9056,7 +9056,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6be8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-660c</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -9110,7 +9110,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6be7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-660b</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -9160,7 +9160,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6be6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-660a</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -9214,7 +9214,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6be5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6609</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -9264,7 +9264,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6be4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6608</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -9318,7 +9318,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6be3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6607</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -9368,7 +9368,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6be2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6606</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -9422,7 +9422,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6be1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6605</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -9472,7 +9472,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6be0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6604</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -9526,7 +9526,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bdf</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6603</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -9576,7 +9576,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bde</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6602</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -9630,7 +9630,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bdd</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6601</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -9679,7 +9679,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6bdc</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6600</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -9722,7 +9722,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bdb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65ff</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -9773,7 +9773,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bda</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65fe</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -9824,7 +9824,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bd9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65fd</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -9875,7 +9875,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bd8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65fc</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -9926,7 +9926,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bd7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65fb</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -9977,7 +9977,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bd6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65fa</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10028,7 +10028,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bd5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65f9</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10079,7 +10079,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bd4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65f8</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10130,7 +10130,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bd3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65f7</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10181,7 +10181,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bd2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65f6</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10232,7 +10232,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bd1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65f5</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10283,7 +10283,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bd0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65f4</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10334,7 +10334,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bcf</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65f3</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10385,7 +10385,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bce</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65f2</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10434,7 +10434,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6bcd</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65f1</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -10477,7 +10477,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bcc</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65f0</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10528,7 +10528,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bcb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65ef</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10579,7 +10579,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bca</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65ee</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10630,7 +10630,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bc9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65ed</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10681,7 +10681,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bc8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65ec</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10732,7 +10732,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bc7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65eb</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10783,7 +10783,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bc6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65ea</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10834,7 +10834,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bc5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65e9</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10885,7 +10885,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bc4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65e8</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10936,7 +10936,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bc3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65e7</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -10987,7 +10987,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bc2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65e6</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -11038,7 +11038,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bc1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65e5</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -11089,7 +11089,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bc0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65e4</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -11140,7 +11140,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bbf</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65e3</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -11191,7 +11191,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bbe</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65e2</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -11242,7 +11242,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bbd</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65e1</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -11319,7 +11319,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bbc</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65e0</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -11354,7 +11354,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bbb</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65df</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -11398,7 +11398,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bba</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65de</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -11448,7 +11448,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bb9</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65dd</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -11491,7 +11491,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bb8</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65dc</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -11545,7 +11545,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bb7</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65db</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -11596,7 +11596,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bb6</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65da</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -11647,7 +11647,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bb5</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65d9</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -11698,7 +11698,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bb4</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65d8</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -11749,7 +11749,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bb3</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65d7</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -11826,7 +11826,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bb2</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65d6</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -11861,7 +11861,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bb1</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65d5</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -11905,7 +11905,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bb0</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65d4</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -11955,7 +11955,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6baf</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65d3</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -11998,7 +11998,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6bae</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65d2</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -12052,7 +12052,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bad</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65d1</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -12103,7 +12103,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bac</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65d0</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -12154,7 +12154,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6bab</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-65cf</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -12205,7 +12205,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6b62</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6586</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -12256,7 +12256,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6b61</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6585</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -12333,7 +12333,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6b60</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6584</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -12368,7 +12368,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6b5f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6583</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -12412,7 +12412,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6b5e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6582</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -12462,7 +12462,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>true</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6b5d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6581</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -12505,7 +12505,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6b5c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6580</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -12576,7 +12576,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6b5b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-657f</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -12627,7 +12627,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6b5a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-657e</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />
@@ -12678,7 +12678,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6b59</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-657d</wuid>
     <auto_size>false</auto_size>
     <rotation_angle>0.0</rotation_angle>
     <scripts />

--- a/ADApp/op/opi/autoconvert/simDetector.opi
+++ b/ADApp/op/opi/autoconvert/simDetector.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-6a4f</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-6473</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -36,7 +36,7 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6a4c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6470</wuid>
     <scripts />
     <height>26</height>
     <name>Grouping Container</name>
@@ -78,7 +78,7 @@
       <line_color>
         <color red="128" green="0" blue="255" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-6a4b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-646f</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -131,7 +131,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6a4a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-646e</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>25</height>
@@ -175,7 +175,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6a49</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-646d</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -216,7 +216,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6a48</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-646c</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -257,7 +257,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6a47</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-646b</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -298,7 +298,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6a46</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-646a</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -339,7 +339,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6a45</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6469</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <zoom_to_fit>true</zoom_to_fit>
@@ -380,7 +380,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6a44</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6468</wuid>
     <scripts />
     <height>360</height>
     <name>Grouping Container</name>
@@ -422,7 +422,7 @@ $(pv_value)</tooltip>
       <line_color>
         <color name="Gray_14" red="0" green="0" blue="0" />
       </line_color>
-      <wuid>12e5a6d8:14c334c9085:-6a41</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6465</wuid>
       <bg_gradient_color>
         <color red="255" green="255" blue="255" />
       </bg_gradient_color>
@@ -477,7 +477,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6a43</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6467</wuid>
       <scripts />
       <height>21</height>
       <name>Grouping Container</name>
@@ -519,7 +519,7 @@ $(pv_value)</tooltip>
         <line_color>
           <color red="128" green="0" blue="255" />
         </line_color>
-        <wuid>12e5a6d8:14c334c9085:-6a42</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6466</wuid>
         <bg_gradient_color>
           <color red="255" green="255" blue="255" />
         </bg_gradient_color>
@@ -575,7 +575,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6a34</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6458</wuid>
       <scripts />
       <height>229</height>
       <name>Grouping Container</name>
@@ -615,7 +615,7 @@ $(pv_value)</tooltip>
           <include_parent_macros>true</include_parent_macros>
         </macros>
         <visible>true</visible>
-        <wuid>12e5a6d8:14c334c9085:-6a2d</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6451</wuid>
         <scripts />
         <height>20</height>
         <name>Grouping Container</name>
@@ -653,7 +653,7 @@ $(pv_value)</tooltip>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <visible>true</visible>
           <vertical_alignment>1</vertical_alignment>
-          <wuid>12e5a6d8:14c334c9085:-6a2c</wuid>
+          <wuid>-1ee33d7e:14c80d1e20e:-6450</wuid>
           <auto_size>false</auto_size>
           <scripts />
           <height>20</height>
@@ -696,7 +696,7 @@ $(pv_value)</tooltip>
           <visible>true</visible>
           <vertical_alignment>1</vertical_alignment>
           <show_units>false</show_units>
-          <wuid>12e5a6d8:14c334c9085:-6a2b</wuid>
+          <wuid>-1ee33d7e:14c80d1e20e:-644f</wuid>
           <auto_size>false</auto_size>
           <rotation_angle>0.0</rotation_angle>
           <scripts />
@@ -748,7 +748,7 @@ $(pv_value)</tooltip>
           <include_parent_macros>true</include_parent_macros>
         </macros>
         <visible>true</visible>
-        <wuid>12e5a6d8:14c334c9085:-6a2a</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-644e</wuid>
         <scripts />
         <height>40</height>
         <name>Grouping Container</name>
@@ -788,7 +788,7 @@ $(pv_value)</tooltip>
             <include_parent_macros>true</include_parent_macros>
           </macros>
           <visible>true</visible>
-          <wuid>12e5a6d8:14c334c9085:-6a28</wuid>
+          <wuid>-1ee33d7e:14c80d1e20e:-644c</wuid>
           <scripts />
           <height>40</height>
           <name>Grouping Container</name>
@@ -826,7 +826,7 @@ $(pv_value)</tooltip>
           <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
             <visible>true</visible>
             <vertical_alignment>1</vertical_alignment>
-            <wuid>12e5a6d8:14c334c9085:-6a27</wuid>
+            <wuid>-1ee33d7e:14c80d1e20e:-644b</wuid>
             <auto_size>false</auto_size>
             <scripts />
             <height>20</height>
@@ -877,7 +877,7 @@ $(pv_value)</tooltip>
           <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
             <visible>true</visible>
             <vertical_alignment>1</vertical_alignment>
-            <wuid>12e5a6d8:14c334c9085:-6a26</wuid>
+            <wuid>-1ee33d7e:14c80d1e20e:-644a</wuid>
             <auto_size>false</auto_size>
             <scripts />
             <height>20</height>
@@ -928,7 +928,7 @@ $(pv_value)</tooltip>
           <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
             <border_alarm_sensitive>false</border_alarm_sensitive>
             <visible>true</visible>
-            <wuid>12e5a6d8:14c334c9085:-6a25</wuid>
+            <wuid>-1ee33d7e:14c80d1e20e:-6449</wuid>
             <scripts />
             <height>20</height>
             <style>1</style>
@@ -981,7 +981,7 @@ $(pv_value)</tooltip>
           <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
             <border_alarm_sensitive>false</border_alarm_sensitive>
             <visible>true</visible>
-            <wuid>12e5a6d8:14c334c9085:-6a24</wuid>
+            <wuid>-1ee33d7e:14c80d1e20e:-6448</wuid>
             <scripts />
             <height>20</height>
             <style>1</style>
@@ -1035,7 +1035,7 @@ $(pv_value)</tooltip>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <visible>true</visible>
           <vertical_alignment>1</vertical_alignment>
-          <wuid>12e5a6d8:14c334c9085:-6a29</wuid>
+          <wuid>-1ee33d7e:14c80d1e20e:-644d</wuid>
           <auto_size>false</auto_size>
           <scripts />
           <height>20</height>
@@ -1079,7 +1079,7 @@ $(pv_value)</tooltip>
           <include_parent_macros>true</include_parent_macros>
         </macros>
         <visible>true</visible>
-        <wuid>12e5a6d8:14c334c9085:-6a23</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6447</wuid>
         <scripts />
         <height>20</height>
         <name>Grouping Container</name>
@@ -1117,7 +1117,7 @@ $(pv_value)</tooltip>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <visible>true</visible>
           <vertical_alignment>1</vertical_alignment>
-          <wuid>12e5a6d8:14c334c9085:-6a22</wuid>
+          <wuid>-1ee33d7e:14c80d1e20e:-6446</wuid>
           <auto_size>false</auto_size>
           <scripts />
           <height>20</height>
@@ -1160,7 +1160,7 @@ $(pv_value)</tooltip>
           <visible>true</visible>
           <vertical_alignment>1</vertical_alignment>
           <show_units>false</show_units>
-          <wuid>12e5a6d8:14c334c9085:-6a21</wuid>
+          <wuid>-1ee33d7e:14c80d1e20e:-6445</wuid>
           <auto_size>false</auto_size>
           <rotation_angle>0.0</rotation_angle>
           <scripts />
@@ -1212,7 +1212,7 @@ $(pv_value)</tooltip>
           <include_parent_macros>true</include_parent_macros>
         </macros>
         <visible>true</visible>
-        <wuid>12e5a6d8:14c334c9085:-6a20</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6444</wuid>
         <scripts />
         <height>20</height>
         <name>Grouping Container</name>
@@ -1252,7 +1252,7 @@ $(pv_value)</tooltip>
             <include_parent_macros>true</include_parent_macros>
           </macros>
           <visible>true</visible>
-          <wuid>12e5a6d8:14c334c9085:-6a1f</wuid>
+          <wuid>-1ee33d7e:14c80d1e20e:-6443</wuid>
           <scripts />
           <height>20</height>
           <name>Grouping Container</name>
@@ -1318,7 +1318,7 @@ $(pv_value)</tooltip>
             <minimum>-Infinity</minimum>
             <next_focus>0</next_focus>
             <show_units>false</show_units>
-            <wuid>12e5a6d8:14c334c9085:-6a1e</wuid>
+            <wuid>-1ee33d7e:14c80d1e20e:-6442</wuid>
             <rotation_angle>0.0</rotation_angle>
             <style>0</style>
             <name>Text Input</name>
@@ -1354,7 +1354,7 @@ $(pv_value)</tooltip>
             <visible>true</visible>
             <vertical_alignment>1</vertical_alignment>
             <show_units>false</show_units>
-            <wuid>12e5a6d8:14c334c9085:-6a1d</wuid>
+            <wuid>-1ee33d7e:14c80d1e20e:-6441</wuid>
             <auto_size>false</auto_size>
             <rotation_angle>0.0</rotation_angle>
             <scripts />
@@ -1404,7 +1404,7 @@ $(pv_value)</tooltip>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <visible>true</visible>
           <vertical_alignment>1</vertical_alignment>
-          <wuid>12e5a6d8:14c334c9085:-6a1c</wuid>
+          <wuid>-1ee33d7e:14c80d1e20e:-6440</wuid>
           <auto_size>false</auto_size>
           <scripts />
           <height>20</height>
@@ -1448,7 +1448,7 @@ $(pv_value)</tooltip>
           <include_parent_macros>true</include_parent_macros>
         </macros>
         <visible>true</visible>
-        <wuid>12e5a6d8:14c334c9085:-6a1b</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-643f</wuid>
         <scripts />
         <height>20</height>
         <name>Grouping Container</name>
@@ -1486,7 +1486,7 @@ $(pv_value)</tooltip>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <visible>true</visible>
           <vertical_alignment>1</vertical_alignment>
-          <wuid>12e5a6d8:14c334c9085:-6a1a</wuid>
+          <wuid>-1ee33d7e:14c80d1e20e:-643e</wuid>
           <auto_size>false</auto_size>
           <scripts />
           <height>20</height>
@@ -1529,7 +1529,7 @@ $(pv_value)</tooltip>
           <visible>true</visible>
           <vertical_alignment>1</vertical_alignment>
           <show_units>false</show_units>
-          <wuid>12e5a6d8:14c334c9085:-6a19</wuid>
+          <wuid>-1ee33d7e:14c80d1e20e:-643d</wuid>
           <auto_size>false</auto_size>
           <rotation_angle>0.0</rotation_angle>
           <scripts />
@@ -1580,7 +1580,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>true</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-6a33</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6457</wuid>
         <scripts />
         <height>20</height>
         <name>Menu Button</name>
@@ -1622,7 +1622,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6a32</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6456</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -1665,7 +1665,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6a31</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6455</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1714,7 +1714,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6a30</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6454</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -1756,7 +1756,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>true</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-6a2f</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6453</wuid>
         <scripts />
         <height>20</height>
         <name>Menu Button</name>
@@ -1800,7 +1800,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6a2e</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6452</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1849,7 +1849,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6a18</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-643c</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -1891,7 +1891,7 @@ $(pv_value)</tooltip>
         <border_alarm_sensitive>false</border_alarm_sensitive>
         <visible>true</visible>
         <actions_from_pv>true</actions_from_pv>
-        <wuid>12e5a6d8:14c334c9085:-6a17</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-643b</wuid>
         <scripts />
         <height>20</height>
         <name>Menu Button</name>
@@ -1935,7 +1935,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6a16</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-643a</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1985,7 +1985,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6a40</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6464</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2026,7 +2026,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6a3f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6463</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2095,7 +2095,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6a3e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6462</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -2131,7 +2131,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6a3d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6461</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2180,7 +2180,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6a3c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6460</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2249,7 +2249,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6a3b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-645f</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -2285,7 +2285,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6a3a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-645e</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2334,7 +2334,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6a39</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-645d</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2403,7 +2403,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6a38</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-645c</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -2439,7 +2439,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6a37</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-645b</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2488,7 +2488,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6a36</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-645a</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2531,7 +2531,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6a35</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6459</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2582,7 +2582,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6a4e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6472</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -2633,7 +2633,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6a4d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6471</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>

--- a/ADApp/op/opi/autoconvert/simDetectorSetup.opi
+++ b/ADApp/op/opi/autoconvert/simDetectorSetup.opi
@@ -3,7 +3,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <wuid>12e5a6d8:14c334c9085:-696c</wuid>
+  <wuid>-1ee33d7e:14c80d1e20e:-6390</wuid>
   <boy_version>3.2.10.20140131</boy_version>
   <scripts />
   <show_ruler>true</show_ruler>
@@ -38,7 +38,7 @@
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6967</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-638b</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -95,7 +95,7 @@ $(pv_value)</tooltip>
     <line_color>
       <color name="Gray_14" red="0" green="0" blue="0" />
     </line_color>
-    <wuid>12e5a6d8:14c334c9085:-6962</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6386</wuid>
     <bg_gradient_color>
       <color red="255" green="255" blue="255" />
     </bg_gradient_color>
@@ -150,7 +150,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6965</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6389</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -189,7 +189,7 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
       <actions_from_pv>true</actions_from_pv>
-      <wuid>12e5a6d8:14c334c9085:-6964</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6388</wuid>
       <scripts />
       <height>20</height>
       <name>Menu Button</name>
@@ -231,7 +231,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-6963</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6387</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -275,7 +275,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-6961</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6385</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -315,7 +315,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6960</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6384</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -392,7 +392,7 @@ $(pv_value)</tooltip>
       <minimum>-Infinity</minimum>
       <next_focus>0</next_focus>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-695f</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6383</wuid>
       <rotation_angle>0.0</rotation_angle>
       <style>0</style>
       <name>Text Input</name>
@@ -426,7 +426,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-695e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6382</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -470,7 +470,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-695d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6381</wuid>
     <scripts />
     <height>145</height>
     <name>Grouping Container</name>
@@ -510,7 +510,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-695c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6380</wuid>
       <scripts />
       <height>145</height>
       <name>Grouping Container</name>
@@ -548,7 +548,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-695b</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-637f</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -589,7 +589,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-695a</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-637e</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -630,7 +630,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6959</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-637d</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -671,7 +671,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6958</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-637c</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -712,7 +712,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6957</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-637b</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -753,7 +753,7 @@ $(pv_value)</tooltip>
       <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
-        <wuid>12e5a6d8:14c334c9085:-6956</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-637a</wuid>
         <auto_size>false</auto_size>
         <scripts />
         <height>20</height>
@@ -797,7 +797,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6955</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6379</wuid>
       <scripts />
       <height>145</height>
       <name>Grouping Container</name>
@@ -863,7 +863,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6954</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6378</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -925,7 +925,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6953</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6377</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -987,7 +987,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6952</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6376</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -1049,7 +1049,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6951</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6375</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -1111,7 +1111,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6950</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6374</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -1173,7 +1173,7 @@ $(pv_value)</tooltip>
         <minimum>-Infinity</minimum>
         <next_focus>0</next_focus>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-694f</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6373</wuid>
         <rotation_angle>0.0</rotation_angle>
         <style>0</style>
         <name>Text Input</name>
@@ -1210,7 +1210,7 @@ $(pv_value)</tooltip>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-694e</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6372</wuid>
       <scripts />
       <height>143</height>
       <name>Grouping Container</name>
@@ -1250,7 +1250,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-694d</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6371</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1301,7 +1301,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-694c</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-6370</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1352,7 +1352,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-694b</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-636f</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1403,7 +1403,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-694a</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-636e</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1454,7 +1454,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6949</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-636d</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1505,7 +1505,7 @@ $(pv_value)</tooltip>
         <visible>true</visible>
         <vertical_alignment>1</vertical_alignment>
         <show_units>false</show_units>
-        <wuid>12e5a6d8:14c334c9085:-6948</wuid>
+        <wuid>-1ee33d7e:14c80d1e20e:-636c</wuid>
         <auto_size>false</auto_size>
         <rotation_angle>0.0</rotation_angle>
         <scripts />
@@ -1558,7 +1558,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-693e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6362</wuid>
     <scripts />
     <height>217</height>
     <name>Grouping Container</name>
@@ -1598,7 +1598,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-693d</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6361</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1649,7 +1649,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-693c</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6360</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1700,7 +1700,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-693b</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-635f</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1751,7 +1751,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-693a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-635e</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1802,7 +1802,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6939</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-635d</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1853,7 +1853,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6938</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-635c</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1904,7 +1904,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6937</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-635b</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -1955,7 +1955,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6936</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-635a</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2006,7 +2006,7 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
       <show_units>false</show_units>
-      <wuid>12e5a6d8:14c334c9085:-6935</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-6359</wuid>
       <auto_size>false</auto_size>
       <rotation_angle>0.0</rotation_angle>
       <scripts />
@@ -2058,7 +2058,7 @@ $(pv_value)</tooltip>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <visible>true</visible>
-    <wuid>12e5a6d8:14c334c9085:-692b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-634f</wuid>
     <scripts />
     <height>20</height>
     <name>Grouping Container</name>
@@ -2096,7 +2096,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <visible>true</visible>
       <vertical_alignment>1</vertical_alignment>
-      <wuid>12e5a6d8:14c334c9085:-692a</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-634e</wuid>
       <auto_size>false</auto_size>
       <scripts />
       <height>20</height>
@@ -2137,7 +2137,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <visible>true</visible>
-      <wuid>12e5a6d8:14c334c9085:-6929</wuid>
+      <wuid>-1ee33d7e:14c80d1e20e:-634d</wuid>
       <scripts />
       <height>20</height>
       <style>1</style>
@@ -2191,7 +2191,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-696b</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-638f</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>25</height>
@@ -2232,7 +2232,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-696a</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-638e</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2273,7 +2273,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6969</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-638d</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2315,7 +2315,7 @@ $(pv_value)</tooltip>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <visible>true</visible>
     <actions_from_pv>false</actions_from_pv>
-    <wuid>12e5a6d8:14c334c9085:-6968</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-638c</wuid>
     <scripts />
     <height>20</height>
     <name>Menu Button</name>
@@ -2366,7 +2366,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6966</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-638a</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -2435,7 +2435,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6947</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-636b</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -2497,7 +2497,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6946</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-636a</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -2559,7 +2559,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6945</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6369</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -2621,7 +2621,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6944</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6368</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -2683,7 +2683,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6943</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6367</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -2745,7 +2745,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6942</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6366</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -2807,7 +2807,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6941</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6365</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -2869,7 +2869,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-6940</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6364</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -2931,7 +2931,7 @@ $(pv_value)</tooltip>
     <minimum>-Infinity</minimum>
     <next_focus>0</next_focus>
     <show_units>false</show_units>
-    <wuid>12e5a6d8:14c334c9085:-693f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6363</wuid>
     <rotation_angle>0.0</rotation_angle>
     <style>0</style>
     <name>Text Input</name>
@@ -2965,7 +2965,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6934</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6358</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3006,7 +3006,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6933</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6357</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3047,7 +3047,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6932</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6356</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3088,7 +3088,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6931</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6355</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3129,7 +3129,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-6930</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6354</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3170,7 +3170,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-692f</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6353</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3211,7 +3211,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-692e</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6352</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3252,7 +3252,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-692d</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6351</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>
@@ -3293,7 +3293,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <visible>true</visible>
     <vertical_alignment>1</vertical_alignment>
-    <wuid>12e5a6d8:14c334c9085:-692c</wuid>
+    <wuid>-1ee33d7e:14c80d1e20e:-6350</wuid>
     <auto_size>false</auto_size>
     <scripts />
     <height>20</height>

--- a/ADApp/op/ui/autoconvert/ADCollect.ui
+++ b/ADApp/op/ui/autoconvert/ADCollect.ui
@@ -16,6 +16,94 @@
 QWidget#centralWidget {background: rgba(187, 187, 187, 255);}
 QPushButton::menu-indicator {image: url(none.png); width: 0}
 
+caTable {
+       font: 10pt;
+       background: cornsilk;
+       alternate-background-color: wheat;
+}
+
+caLineEdit {
+     border-radius: 1px;
+     background: lightyellow;
+     color: black;
+ }
+
+caTextEntry {
+    color: rgb(127, 0, 63);
+    background-color: cornsilk;
+    selection-color: #0a214c;
+    selection-background-color: wheat;
+    border: 1px groove black;
+    border-radius: 1px;
+    padding: 1px;
+}
+
+caTextEntry:focus {
+    padding: 0px;
+    border: 2px groove darkred;
+    border-radius: 1px;
+}
+
+QPushButton {
+      border-color: #00b;
+      border-radius: 2px;
+      padding: 3px;
+      border-width: 1px;
+
+	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
+						   stop:0   rgba(224, 239, 255, 255),
+						   stop:0.5 rgba(199, 215, 230, 255),
+						   stop:1   rgba(184, 214, 236, 255));
+}
+QPushButton:hover {
+	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
+						stop:0   rgba(201, 226, 255, 255),
+						stop:0.5 rgba(177, 204, 230, 255),
+						stop:1   rgba(163, 205, 236, 255));
+}
+QPushButton:pressed {
+	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
+						stop:0   rgba(174, 219, 255, 255),
+						stop:0.5 rgba(165, 199, 230, 255),
+						stop:1   rgba(134, 188, 236, 255));
+}
+
+QPushButton:disabled {
+	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
+						stop:0   rgba(174, 219, 255, 255),
+						stop:0.5 rgba(165, 199, 230, 255),
+						stop:1   rgba(134, 188, 236, 255));
+}
+
+caChoice {
+      background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+                                  stop: 0 #E1E1E1, stop: 0.4 #DDDDDD,
+                                  stop: 0.5 #D8D8D8, stop: 1.0 #D3D3D3);
+}
+
+caChoice &gt; QPushButton {
+      text-align: left;
+      padding: 1px;
+}
+
+caSlider::groove:horizontal {
+border: 1px solid #bbb;
+background: lightgrey;
+height: 20px;
+border-radius: 4px;
+}
+
+caSlider::handle:horizontal {
+background: red;
+border: 1px solid #777;
+width: 13px;
+margin-top: -2px;
+margin-bottom: -2px;
+border-radius: 2px;
+}
+
+
+
 </string>
     </property>
     <widget class="QWidget" name="centralWidget">

--- a/ADApp/op/ui/autoconvert/NDPluginBase.ui
+++ b/ADApp/op/ui/autoconvert/NDPluginBase.ui
@@ -16,6 +16,94 @@
 QWidget#centralWidget {background: rgba(187, 187, 187, 255);}
 QPushButton::menu-indicator {image: url(none.png); width: 0}
 
+caTable {
+       font: 10pt;
+       background: cornsilk;
+       alternate-background-color: wheat;
+}
+
+caLineEdit {
+     border-radius: 1px;
+     background: lightyellow;
+     color: black;
+ }
+
+caTextEntry {
+    color: rgb(127, 0, 63);
+    background-color: cornsilk;
+    selection-color: #0a214c;
+    selection-background-color: wheat;
+    border: 1px groove black;
+    border-radius: 1px;
+    padding: 1px;
+}
+
+caTextEntry:focus {
+    padding: 0px;
+    border: 2px groove darkred;
+    border-radius: 1px;
+}
+
+QPushButton {
+      border-color: #00b;
+      border-radius: 2px;
+      padding: 3px;
+      border-width: 1px;
+
+	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
+						   stop:0   rgba(224, 239, 255, 255),
+						   stop:0.5 rgba(199, 215, 230, 255),
+						   stop:1   rgba(184, 214, 236, 255));
+}
+QPushButton:hover {
+	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
+						stop:0   rgba(201, 226, 255, 255),
+						stop:0.5 rgba(177, 204, 230, 255),
+						stop:1   rgba(163, 205, 236, 255));
+}
+QPushButton:pressed {
+	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
+						stop:0   rgba(174, 219, 255, 255),
+						stop:0.5 rgba(165, 199, 230, 255),
+						stop:1   rgba(134, 188, 236, 255));
+}
+
+QPushButton:disabled {
+	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
+						stop:0   rgba(174, 219, 255, 255),
+						stop:0.5 rgba(165, 199, 230, 255),
+						stop:1   rgba(134, 188, 236, 255));
+}
+
+caChoice {
+      background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+                                  stop: 0 #E1E1E1, stop: 0.4 #DDDDDD,
+                                  stop: 0.5 #D8D8D8, stop: 1.0 #D3D3D3);
+}
+
+caChoice &gt; QPushButton {
+      text-align: left;
+      padding: 1px;
+}
+
+caSlider::groove:horizontal {
+border: 1px solid #bbb;
+background: lightgrey;
+height: 20px;
+border-radius: 4px;
+}
+
+caSlider::handle:horizontal {
+background: red;
+border: 1px solid #777;
+width: 13px;
+margin-top: -2px;
+margin-bottom: -2px;
+border-radius: 2px;
+}
+
+
+
 </string>
     </property>
     <widget class="QWidget" name="centralWidget">

--- a/ADApp/pluginSrc/Makefile
+++ b/ADApp/pluginSrc/Makefile
@@ -89,10 +89,6 @@ endif
 ifeq ($(EPICS_V4_PLUGIN), YES)
   DBD += NDPluginV4Server.dbd
   INC += NDPluginV4Server.h
-  USR_INCLUDES += -I$(EV4_BASE)/pvDataCPP/include
-  USR_INCLUDES += -I$(EV4_BASE)/pvDatabaseCPP/include
-  USR_INCLUDES += -I$(EV4_BASE)/pvAccessCPP/include
-  USR_INCLUDES += -I$(EV4_BASE)/normativeTypesCPP/include
   NDPlugin_SRCS += NDPluginV4Server.cpp
 endif
 

--- a/ADApp/pluginSrc/NDPluginFile.cpp
+++ b/ADApp/pluginSrc/NDPluginFile.cpp
@@ -67,8 +67,6 @@ asynStatus NDPluginFile::openFileBase(NDFileOpenMode_t openMode, NDArray *pArray
     }
 
     /* Call the openFile method in the derived class */
-    /* Do this with the main lock released since it is slow */
-    this->unlock();
     epicsMutexLock(this->fileMutexId);
     this->registerInitFrameInfo(pArray);
     status = this->openFile(fullFileName, openMode, pArray);
@@ -82,7 +80,6 @@ asynStatus NDPluginFile::openFileBase(NDFileOpenMode_t openMode, NDArray *pArray
         setStringParam(NDFileWriteMessage, errorMessage);
     }
     epicsMutexUnlock(this->fileMutexId);
-    this->lock();
     
     return(status);
 }
@@ -105,14 +102,17 @@ asynStatus NDPluginFile::closeFileBase()
     getStringParam(NDFullFileName, sizeof(fullFileName), fullFileName);
     getStringParam(NDFileTempSuffix, sizeof(tempSuffix), tempSuffix);
 
-    /* Call the closeFile method in the derived class */
-    /* Do this with the main lock released since it is slow */
-    this->unlock();
+     /* Call the closeFile method in the derived class */
     epicsMutexLock(this->fileMutexId);
     status = this->closeFile();
     if (status) {
         epicsSnprintf(errorMessage, sizeof(errorMessage)-1, 
             "Error closing file, status=%d", status);
+        asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, 
+              "%s:%s %s\n", 
+              driverName, functionName, errorMessage);
+        setIntegerParam(NDFileWriteStatus, NDFileWriteError);
+        setStringParam(NDFileWriteMessage, errorMessage);
     }
 
     if ( *tempSuffix != 0 && 
@@ -122,20 +122,15 @@ asynStatus NDPluginFile::closeFileBase()
         if ( rename( tempFileName, fullFileName ) != 0 ) {
             epicsSnprintf(errorMessage, sizeof(errorMessage)-1, 
                           "Error renaming temporary file %s to %s", tempFileName, fullFileName );
+            asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, 
+                      "%s:%s %s\n", 
+                      driverName, functionName, errorMessage);
             status=asynError;
         }
     }
 
     epicsMutexUnlock(this->fileMutexId);
-    this->lock();
-    if (status) {
-        asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, 
-              "%s:%s %s\n", 
-              driverName, functionName, errorMessage);
-        setIntegerParam(NDFileWriteStatus, NDFileWriteError);
-        setStringParam(NDFileWriteMessage, errorMessage);
-    }
-
+    
     return(status);
 }
 

--- a/ADApp/pvaDriverSrc/Makefile
+++ b/ADApp/pvaDriverSrc/Makefile
@@ -17,10 +17,6 @@ INC += pvaDriver.h
 LIBRARY_IOC = pvaDriver
 LIB_SRCS += pvaDriver.cpp
 
-USR_INCLUDES += -I$(EV4_BASE)/pvDataCPP/include
-USR_INCLUDES += -I$(EV4_BASE)/pvAccessCPP/include
-USR_INCLUDES += -I$(EV4_BASE)/normativeTypesCPP/include
-
 DBD += pvaDriverSupport.dbd
 
 include $(TOP)/ADApp/commonLibraryMakefile

--- a/ADApp/pvaDriverSrc/pvaDriver.cpp
+++ b/ADApp/pvaDriverSrc/pvaDriver.cpp
@@ -265,10 +265,6 @@ void pvaDriver::monitorEvent(MonitorPtr const & monitor)
         }
         lock();
 
-        int imageCounter;
-        getIntegerParam(NDArrayCounter, &imageCounter);
-        setIntegerParam(NDArrayCounter, imageCounter+1);
-
         int xSize     = pImage->dims[info.x.dim].size;
         int ySize     = pImage->dims[info.y.dim].size;
         setIntegerParam(ADMaxSizeX,   xSize);
@@ -298,6 +294,14 @@ void pvaDriver::monitorEvent(MonitorPtr const & monitor)
             doCallbacksGenericPointer(pImage, NDArrayData, 0);
             lock();
         }
+
+        // Update the counters as per convention: after doCallbacksGenericPointer()
+        int imageCounter;
+        getIntegerParam(NDArrayCounter, &imageCounter);
+        setIntegerParam(NDArrayCounter, imageCounter+1);
+        getIntegerParam(ADNumImagesCounter, &imageCounter);
+        setIntegerParam(ADNumImagesCounter, imageCounter+1);
+        callParamCallbacks();
 
         pImage->release();
         monitor->release(update);

--- a/ADApp/pvaDriverSrc/pvaDriver.cpp
+++ b/ADApp/pvaDriverSrc/pvaDriver.cpp
@@ -32,7 +32,7 @@ using namespace epics::nt;
 static const char *driverName = "pvaDriver";
 
 PVARequester::PVARequester(const char *name, asynUser *user) :
-        m_name(name), m_asynUser(user) {}
+        m_asynUser(user), m_name(name) {}
 
 string PVARequester::getRequesterName (void)
 {

--- a/ADApp/pvaDriverSrc/pvaDriver.cpp
+++ b/ADApp/pvaDriverSrc/pvaDriver.cpp
@@ -211,10 +211,17 @@ void pvaDriver::monitorConnect(Status const & status,
 void pvaDriver::monitorEvent(MonitorPtr const & monitor)
 {
     const char *functionName = "monitorEvent";
+    asynPrint(pasynUserSelf, ASYN_TRACE_FLOW,
+            "%s::%s Event!\n",
+            driverName, functionName);
     lock();
     MonitorElementPtr update;
     while ((update = monitor->poll()))
     {
+        asynPrint(pasynUserSelf, ASYN_TRACE_FLOW,
+                 "%s::%s update!\n",
+                 driverName, functionName);
+
         if(!update->overrunBitSet->isEmpty())
         {
             int overrunCounter;
@@ -244,6 +251,9 @@ void pvaDriver::monitorEvent(MonitorPtr const & monitor)
 
         if(!pImage)
         {
+            asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
+                     "%s::%s failed to alloc new NDArray - memory pool exhausted? (free: %d)\n",
+                     driverName, functionName, pNDArrayPool->numFree());
             monitor->release(update);
             continue;
         }
@@ -251,6 +261,9 @@ void pvaDriver::monitorEvent(MonitorPtr const & monitor)
         unlock();
         try
         {
+            asynPrint(pasynUserSelf, ASYN_TRACE_FLOW,
+                      "%s::%s Converting to NDArray\n",
+                      driverName, functionName);
             converter.toArray(pImage);
         }
         catch(...)
@@ -287,9 +300,11 @@ void pvaDriver::monitorEvent(MonitorPtr const & monitor)
 
         int arrayCallbacks;
         getIntegerParam(NDArrayCallbacks, &arrayCallbacks);
-
         if(arrayCallbacks)
         {
+            asynPrint(pasynUserSelf, ASYN_TRACE_FLOW,
+                      "%s::%s Callback with NDArray (%p)\n",
+                      driverName, functionName, pImage);
             unlock();
             doCallbacksGenericPointer(pImage, NDArrayData, 0);
             lock();

--- a/ADApp/pvaDriverSrc/pvaDriver.h
+++ b/ADApp/pvaDriverSrc/pvaDriver.h
@@ -9,7 +9,6 @@ class pvaDriver;
 
 typedef epics::pvAccess::Channel::shared_pointer ChannelPtr;
 typedef epics::pvAccess::ChannelProvider::shared_pointer ChannelProviderPtr;
-typedef std::tr1::shared_ptr<epics::pvData::MonitorElement> MonitorElementPtr;
 typedef std::tr1::shared_ptr<PVAChannelRequester> PVAChannelRequesterPtr;
 typedef std::tr1::shared_ptr<pvaDriver> pvaDriverPtr;
 

--- a/ADApp/pvaDriverSrc/pvaDriver.h
+++ b/ADApp/pvaDriverSrc/pvaDriver.h
@@ -2,7 +2,9 @@
 #include <pv/pvAccess.h>
 #include <pv/ntndarray.h>
 
-#define PVAOverrunCounterString   "OVERRUN_COUNTER"
+#define PVAOverrunCounterString     "OVERRUN_COUNTER"
+#define PVAPvNameString             "PV_NAME"
+#define PVAPvConnectionStatusString "PV_CONNECTION"
 
 class PVAChannelRequester;
 class pvaDriver;
@@ -58,6 +60,8 @@ public:
 
 protected:
     int PVAOverrunCounter;
+    int PVAPvName;
+    int PVAPvConnectionStatus;
 
 private:
     std::string m_pvName;

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,6 +23,20 @@ files respectively, in the configure/ directory of the appropriate release of th
 Release Notes
 =============
 
+
+R2-3 (April XXX, 2015)
+========================
+### NDPluginFile
+* Fixed a serious performance problem.  The calls to openFile() and closeFile() in the derived file 
+  writing classes were being done with the asynPortDriver mutex locked.
+  This meant that driver callbacks were blocked from putting entries on the queue during this time, 
+  slowing down the drivers and potentially causing them to drop frames.  
+  Changed openFileBase() and closeFileBase() to unlock the mutex during these operations.  
+  Testing with the simDetector and ADDexela shows that the new version no longer slows
+  down the driver or drops frames at the driver level when saving TIFF files or netCDF files 
+  in Single mode.
+
+
 R2-2 (March 23, 2015)
 ========================
 ### Compatibility

--- a/iocs/pvaDriverIOC/iocBoot/iocPvaDriver/st.cmd
+++ b/iocs/pvaDriverIOC/iocBoot/iocPvaDriver/st.cmd
@@ -17,6 +17,8 @@ epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES", "1000000")
 # Create a pvaDriver
 # pvaDriverConfig(portName, pvName, maxBuffers, maxMemory, priority, stackSize)
 pvaDriverConfig("$(PORT)", "$(PVNAME)", $(QSIZE), 0, 0)
+asynSetTraceMask $(PORT) 0 0xFF
+asynSetTraceInfoMask $(PORT) 0 0x7
 dbLoadRecords("pvaDriver.template","P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")
 
 # Create a standard arrays plugin, set it to get data from pvaDriver
@@ -24,3 +26,7 @@ NDStdArraysConfigure("Image1", $(QSIZE), 1, "$(PORT)", 0)
 dbLoadRecords("NDStdArrays.template", "P=$(PREFIX),R=image1:,PORT=Image1,ADDR=0,TIMEOUT=1,NDARRAY_PORT=$(PORT),TYPE=Int8,FTVL=UCHAR,NELEMENTS=$(NELM)")
 
 iocInit()
+
+# Silence a very chatty ASYN_TRACE_FLOW
+# Remove this if performance testing
+dbpf 13PVA1:cam1:PoolUsedMem.SCAN Passive

--- a/iocs/simDetectorIOC/iocBoot/iocSimDetector/st.cmd
+++ b/iocs/simDetectorIOC/iocBoot/iocSimDetector/st.cmd
@@ -15,7 +15,7 @@ epicsEnvSet("QSIZE",  "20")
 epicsEnvSet("XSIZE",  "1024")
 # The maximim image height; used for column profiles in the NDPluginStats plugin
 epicsEnvSet("YSIZE",  "1024")
-# The maximum number of time seried points in the NDPluginStats plugin
+# The maximum number of time series points in the NDPluginStats plugin
 epicsEnvSet("NCHANS", "2048")
 # The maximum number of frames buffered in the NDPluginCircularBuff plugin
 epicsEnvSet("CBUFFS", "500")


### PR DESCRIPTION
Hi @brunoseivam 

This is just a PR for information so you can easily pull in my recent changes from ADCore...

I have mainly just been updating and tweaking your code so that it is more in line with areaDetector conventions:
- merged current ADCore master into this V4 branch so that it does not fall too far behind.
- Tweaked the build system to treat the V4 modules as regular EPICS support modules (avoiding use of USR_INCLUDE etc.). 
  - The V4 modules now need to be listed in configure/RELEASE.local in order to be picked up automatically by the build system.
  - The EPICS_V4_PLUGIN=YES macro need to be defined in configure/CONFIG_SITE.< arch >.Common
- Added a couple of parameters to the pvaDriver to allow reading the V4 PV name and connection status.
- Fixed some compilation errors and warnings.

Check the commit logs from today for the details of what I've changed...

The new connection status parameter does not work properly yet: unlisten() does not appear to get called when the V4 PV goes away so the parameter never gets set back to 0 on loss of connection. Perhaps you have a suggestion on how to make that work?
