### PR TITLE
Fix unsafe write to structure array

### DIFF
--- a/ADApp/ntndArrayConverterSrc/ntndArrayConverter.cpp
+++ b/ADApp/ntndArrayConverterSrc/ntndArrayConverter.cpp
@@ -504,7 +504,7 @@ void NTNDArrayConverter::fromAttributes (NDArray *src)
     size_t i = 0;
     while((attr = srcList->next(attr)))
     {
-        if(!destVec[i].get())
+        if(!destVec[i].get() || !destVec[i].unique())
             destVec[i] = PVDC->createPVStructure(structure);
 
         PVStructurePtr pvAttr(destVec[i]);


### PR DESCRIPTION
NTNDArrayConverter::fromAttributes() calls PVStructureArray::reuse(). When more than one reference is held to the shared_vector this will cause a copy to be made. The elements of both copies will point to the same PVStructures and so a write to the the latter is unsafe.

Fix by checking unique() on the PVStructures. [Compare with the code for PVStructureArray::deserialize().]

Fixes #144
